### PR TITLE
Docs/ event source kpi

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This repository demonstrates the integration of the **Axeptio Flutter SDK** into
 7. [Sharing Consents with Web Views](#sharing-consents-with-web-views)
 8. [Clearing User Consent](#clearing-user-consent)
 9. [Event Handling and Customization](#event-handling-and-customization)
-10. [Local Test](#local-test)
+10. [Event Source Identification](#event-source-for-kpi-tracking)
+11. [Local Test](#local-test)
 <br><br><br>
 ## 🚀Setup and Installation   
 To integrate the Axeptio SDK into your Flutter project, run the following command in your terminal:
@@ -324,6 +325,20 @@ var axeptioSdk = AxeptioSdk();
 axeptioSdkPlugin.addEventListener(listener);
 axeptioSdkPlugin.removeEventListener(listener);
 ```
+<br><br><br>
+
+### Event Source Identification
+
+Events sent from the SDK (including those triggered via the internal WebView) include an `event_source` value to distinguish between App and Web contexts. This ensures analytics and KPIs are correctly attributed in the Axeptio back office.
+
+The following values are used:
+
+- `sdk-app-tcf`: TCF popup inside mobile apps.
+- `sdk-web-tcf`: TCF popup in web browsers.
+- `sdk-app-brands`: Brands widget loaded in apps.
+- `sdk-web`: Brands widget on websites.
+
+This tagging is handled automatically by the native SDK components used under the hood in the Flutter module.
 <br><br><br>
 
 ## Local Test

--- a/README.md
+++ b/README.md
@@ -229,6 +229,42 @@ final brandKeys = [
   "axeptio_all_vendors",
   "axeptio_authorized_vendors",
 ];
+
+final tcfKeys = [
+  'IABTCF_CmpSdkID',
+  'IABTCF_CmpSdkVersion',
+  'IABTCF_PolicyVersion',
+  'IABTCF_gdprApplies',
+  'IABTCF_PublisherCC',
+  'IABTCF_PurposeOneTreatment',
+  'IABTCF_UseNonStandardTexts',
+  'IABTCF_TCString',
+  'IABTCF_VendorConsents',
+  'IABTCF_VendorLegitimateInterests',
+  'IABTCF_PurposeConsents',
+  'IABTCF_PurposeLegitimateInterests',
+  'IABTCF_SpecialFeaturesOptIns',
+  'IABTCF_PublisherRestrictions1',
+  'IABTCF_PublisherRestrictions2',
+  'IABTCF_PublisherRestrictions3',
+  'IABTCF_PublisherRestrictions4',
+  'IABTCF_PublisherRestrictions5',
+  'IABTCF_PublisherRestrictions6',
+  'IABTCF_PublisherRestrictions7',
+  'IABTCF_PublisherRestrictions8',
+  'IABTCF_PublisherRestrictions9',
+  'IABTCF_PublisherRestrictions10',
+  'IABTCF_PublisherRestrictions11',
+  'IABTCF_PublisherConsent',
+  'IABTCF_PublisherLegitimateInterests',
+  'IABTCF_PublisherCustomPurposesConsents',
+  'IABTCF_PublisherCustomPurposesLegitimateInterests',
+  'IABTCF_AddtlConsent',
+  'IABTCF_EnableAdvertiserConsentMode',
+
+  "AX_CLIENT_TOKEN",
+  "AX_POPUP_ON_GOING",
+];
 ```
 > ⚠️ **Note for Android:** On Android, the SDK stores consent data in native preferences. 
 > Using `SharedPreferences.getInstance()` may return `null` if the consent popup was not accepted or if the storage is not shared with Flutter.


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added documentation explaining how the SDK tags events with an event source value to distinguish between app and web contexts for accurate KPI tracking. Also listed TCF consent storage keys used by the SDK.

<!-- End of auto-generated description by cubic. -->

