### PR TITLE
chore: msk-38 - fixing pub.dev credentials

### DIFF
--- a/.github/workflows/dry-run-publish.yml
+++ b/.github/workflows/dry-run-publish.yml
@@ -1,9 +1,5 @@
 name: Dry-run Publish to pub.dev
 on:
-  pull_request:
-    branches: [main, master]
-  push:
-    branches: [main, master]
   workflow_dispatch:
       
 jobs:
@@ -28,6 +24,14 @@ jobs:
         run: flutter test
       - name: Check Publish Warnings (Dry Run)
         run: dart pub publish --dry-run
+      - name: Publish
+        uses: k-paxian/dart-package-publisher@v1.6.2
+        with:
+          accessToken: ${{ secrets.PUB_DEV_PUBLISH_ACCESS_TOKEN }}
+          refreshToken: ${{ secrets.PUB_DEV_PUBLISH_REFRESH_TOKEN }}
+          flutter: true
+          skipTests: true
+          dryRunOnly: true
       - name: Package validation
         run: |
           echo "✅ Package validation completed successfully"

--- a/.github/workflows/dry-run-publish.yml
+++ b/.github/workflows/dry-run-publish.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Check Publish Warnings (Dry Run)
         run: dart pub publish --dry-run
       - name: Publish
-        uses: k-paxian/dart-package-publisher@v1.6.2
+        uses: k-paxian/dart-package-publisher@v1.6
         with:
           accessToken: ${{ secrets.PUB_DEV_PUBLISH_ACCESS_TOKEN }}
           refreshToken: ${{ secrets.PUB_DEV_PUBLISH_REFRESH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,9 @@ jobs:
       - name: Check Publish Warnings
         run: dart pub publish --dry-run
       - name: Publish
-        uses: k-paxian/dart-package-publisher@v1.6
+        uses: k-paxian/dart-package-publisher@v1.6.2
         with:
-          credentialJson: ${{ secrets.CREDENTIAL_JSON }}
-          flutter: true
-          skipTests: true
+            accessToken: ${{ secrets.PUB_DEV_PUBLISH_ACCESS_TOKEN }}
+            refreshToken: ${{ secrets.PUB_DEV_PUBLISH_REFRESH_TOKEN }}
+            flutter: true
+            skipTests: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Check Publish Warnings
         run: dart pub publish --dry-run
       - name: Publish
-        uses: k-paxian/dart-package-publisher@v1.6.2
+        uses: k-paxian/dart-package-publisher@v1.6
         with:
             accessToken: ${{ secrets.PUB_DEV_PUBLISH_ACCESS_TOKEN }}
             refreshToken: ${{ secrets.PUB_DEV_PUBLISH_REFRESH_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ migrate_working_dir/
 **/doc/api/
 .dart_tool/
 build/
+.secrets


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated GitHub Actions workflows to use new pub.dev access and refresh tokens for publishing, and added .secrets to .gitignore.

- **Dependencies**
  - Switched publish actions to use PUB_DEV_PUBLISH_ACCESS_TOKEN and PUB_DEV_PUBLISH_REFRESH_TOKEN.
  - Updated .gitignore to exclude .secrets files.

<!-- End of auto-generated description by cubic. -->

