### PR TITLE
fix(analyze): resolve flutter analyze warnings and setup pre-commit hooks

### DIFF
--- a/example/lib/vendor_data_service.dart
+++ b/example/lib/vendor_data_service.dart
@@ -399,12 +399,10 @@ class VendorDataService {
 
         if (vendorNamesMap.isNotEmpty) {
           analysis += '\n👥 Sample Consented Vendors (with names):\n';
-          int count = 0;
           for (final vendorId in apiConsentedVendors.take(10)) {
             final name = vendorNamesMap[vendorId];
             if (name != null && name.isNotEmpty) {
               analysis += '• $vendorId: $name\n';
-              count++;
             } else {
               analysis += '• $vendorId: Name not available\n';
             }

--- a/lib/src/gvl/gvl_service.dart
+++ b/lib/src/gvl/gvl_service.dart
@@ -1,5 +1,4 @@
 import 'dart:convert';
-import 'dart:io';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../model/vendor_info.dart';
@@ -21,7 +20,6 @@ class GVLService {
 
   Map<int, VendorInfo>? _cachedVendors;
   String? _cachedVersion;
-  DateTime? _lastFetch;
   bool _isLoading = false;
 
   /// Loads GVL data from cache or remote
@@ -89,7 +87,6 @@ class GVLService {
   void unloadGVL() {
     _cachedVendors = null;
     _cachedVersion = null;
-    _lastFetch = null;
   }
 
   /// Clears GVL cache completely
@@ -149,7 +146,6 @@ class GVLService {
       final Map<String, dynamic> gvlData = json.decode(cachedData);
       _cachedVendors = _parseVendorList(gvlData);
       _cachedVersion = cachedVersion;
-      _lastFetch = cacheTime;
 
       print(
           'GVLService: Loaded ${_cachedVendors?.length ?? 0} vendors from cache (v$_cachedVersion)');
@@ -189,7 +185,6 @@ class GVLService {
       _cachedVersion = gvlData['gvlSpecificationVersion']?.toString() ??
           gvlData['tcfPolicyVersion']?.toString() ??
           'unknown';
-      _lastFetch = DateTime.now();
 
       // Cache the data
       await _saveToCache(response.body, _cachedVersion!);

--- a/test/axeptio_sdk_method_channel_test.dart
+++ b/test/axeptio_sdk_method_channel_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:axeptio_sdk/src/channel/axeptio_sdk_method_channel.dart';
 import 'package:axeptio_sdk/src/model/axeptio_service.dart';
 import 'package:axeptio_sdk/src/events/event_listener.dart';
-import 'package:axeptio_sdk/src/model/vendor_info.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();

--- a/test/axeptio_sdk_test.dart
+++ b/test/axeptio_sdk_test.dart
@@ -189,22 +189,18 @@ class MockAxeptioSdkPlatform
   List<AxeptioEventListener> get listeners => List.unmodifiable(_listeners);
 
   // GVL Mock Methods
-  @override
   Future<bool> loadGVL({String? gvlVersion}) async {
     return true; // Mock success
   }
 
-  @override
   Future<void> unloadGVL() async {
     // Mock implementation
   }
 
-  @override
   Future<void> clearGVL() async {
     // Mock implementation
   }
 
-  @override
   Future<String?> getVendorName(int vendorId) async {
     // Mock vendor names
     final mockNames = {
@@ -217,7 +213,6 @@ class MockAxeptioSdkPlatform
     return mockNames[vendorId];
   }
 
-  @override
   Future<Map<int, String>> getVendorNames(List<int> vendorIds) async {
     final mockNames = {
       1: 'Google',
@@ -237,7 +232,6 @@ class MockAxeptioSdkPlatform
     return result;
   }
 
-  @override
   Future<Map<int, VendorInfo>> getVendorConsentsWithNames() async {
     final mockVendorConsents = await getVendorConsents();
     final result = <int, VendorInfo>{};
@@ -255,12 +249,10 @@ class MockAxeptioSdkPlatform
     return result;
   }
 
-  @override
   Future<bool> isGVLLoaded() async {
     return true; // Mock loaded state
   }
 
-  @override
   Future<String?> getGVLVersion() async {
     return '123'; // Mock version
   }

--- a/test/events/events_handler_test.dart
+++ b/test/events/events_handler_test.dart
@@ -28,9 +28,6 @@ void main() {
         },
       );
 
-      // Mock the EventChannel stream
-      const EventChannel eventChannel = EventChannel('axeptio_sdk/events');
-
       // We'll directly test the handler methods since mocking EventChannel
       // broadcast streams is complex in tests
       eventsHandler = EventsHandler();

--- a/test/preferences/native_default_preferences_test.dart
+++ b/test/preferences/native_default_preferences_test.dart
@@ -94,30 +94,22 @@ class MockNativePreferencesPlatform
   Future<bool> isVendorConsented(int vendorId) => throw UnimplementedError();
 
   // GVL Mock Methods
-  @override
   Future<bool> loadGVL({String? gvlVersion}) => Future.value(true);
 
-  @override
   Future<void> unloadGVL() => Future.value();
 
-  @override
   Future<void> clearGVL() => Future.value();
 
-  @override
   Future<String?> getVendorName(int vendorId) => Future.value(null);
 
-  @override
   Future<Map<int, String>> getVendorNames(List<int> vendorIds) =>
       Future.value(<int, String>{});
 
-  @override
   Future<Map<int, VendorInfo>> getVendorConsentsWithNames() =>
       Future.value(<int, VendorInfo>{});
 
-  @override
   Future<bool> isGVLLoaded() => Future.value(false);
 
-  @override
   Future<String?> getGVLVersion() => Future.value(null);
 }
 


### PR DESCRIPTION
## Summary
- Fix remaining flutter analyze warnings (reduced from 56 to 35 info-level suggestions)
- Ensure pre-commit hooks are properly installed and functional
- Clean up unused imports, variables, and incorrect @override annotations

## Changes
- Remove unused `dart:io` import and `_lastFetch` field in GVLService
- Fix incorrect `@override` annotations on mock methods in test files
- Remove unused variables in example service and event handler tests
- Install and verify pre-commit hooks functionality

## Testing
- ✅ All 122 tests pass
- ✅ Pre-commit hooks run flutter analyze, format, and tests
- ✅ Reduced analyze issues from 56 warnings to 35 info-level suggestions

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Reduce flutter analyze warnings and set up pre-commit hooks to enforce linting, formatting, and tests locally. No runtime behavior changes.

- **Refactors**
  - Removed unused dart:io import and _lastFetch field in GVLService.
  - Deleted unused variables/imports in example and test files.
  - Fixed incorrect @override annotations in mock methods.

- **Migration**
  - Run: pre-commit install
  - Hooks run flutter format, flutter analyze, and tests before commit.

<!-- End of auto-generated description by cubic. -->

