### PR TITLE
fix(ci): prevent CI failure on flutter analyze info messages

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+
       - name: Set up Flutter
         uses: subosito/flutter-action@v2
         with:
@@ -25,25 +25,25 @@ jobs:
           channel: 'stable'
           architecture: 'x64'
           cache: false
-      
+
       - name: Install dependencies
         run: flutter pub get
-      
+
       - name: Verify dependencies
         run: flutter pub deps
-        
+
       - name: Check formatting
         run: dart format --output=none --set-exit-if-changed .
-        
+
       - name: Analyze code
-        run: flutter analyze
-        
+        run: flutter analyze --no-fatal-infos
+
       - name: Run tests
         run: flutter test --coverage
-        
+
       - name: Check publish warnings
         run: dart pub publish --dry-run
-        
+
       - name: Upload coverage reports
         uses: codecov/codecov-action@v4
         if: github.event_name == 'pull_request'
@@ -51,4 +51,3 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage/lcov.info
           fail_ci_if_error: false
-


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Update CI to run flutter analyze with --no-fatal-infos so info-level lints no longer fail the build.

<!-- End of auto-generated description by cubic. -->

