### PR TITLE
fix(core): eliminate all flutter analyze info-level warnings

### DIFF
--- a/example/lib/vendor_screen.dart
+++ b/example/lib/vendor_screen.dart
@@ -281,11 +281,11 @@ class _VendorScreenState extends State<VendorScreen> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Row(
+            const Row(
               children: [
-                const Icon(Icons.storage, color: Colors.purple),
-                const SizedBox(width: 8),
-                const Text(
+                Icon(Icons.storage, color: Colors.purple),
+                SizedBox(width: 8),
+                Text(
                   'Global Vendor List (GVL)',
                   style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                 ),

--- a/lib/src/gvl/gvl_service.dart
+++ b/lib/src/gvl/gvl_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:developer' as developer;
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../model/vendor_info.dart';
@@ -36,7 +37,7 @@ class GVLService {
       // Fetch from remote
       return await _fetchFromRemote(gvlVersion);
     } catch (error) {
-      print('GVLService: Error loading GVL - $error');
+      developer.log('Error loading GVL', error: error, name: 'GVLService');
       return false;
     } finally {
       _isLoading = false;
@@ -147,11 +148,13 @@ class GVLService {
       _cachedVendors = _parseVendorList(gvlData);
       _cachedVersion = cachedVersion;
 
-      print(
-          'GVLService: Loaded ${_cachedVendors?.length ?? 0} vendors from cache (v$_cachedVersion)');
+      developer.log(
+          'Loaded ${_cachedVendors?.length ?? 0} vendors from cache (v$_cachedVersion)',
+          name: 'GVLService');
       return true;
     } catch (error) {
-      print('GVLService: Error loading from cache - $error');
+      developer.log('Error loading from cache',
+          error: error, name: 'GVLService');
       return false;
     }
   }
@@ -164,7 +167,7 @@ class GVLService {
         url = '$_baseUrl/vendor-list-v$specificVersion.json';
       }
 
-      print('GVLService: Fetching GVL from $url');
+      developer.log('Fetching GVL from $url', name: 'GVLService');
 
       final response = await http.get(
         Uri.parse(url),
@@ -175,8 +178,8 @@ class GVLService {
       ).timeout(const Duration(seconds: 30));
 
       if (response.statusCode != 200) {
-        print(
-            'GVLService: HTTP ${response.statusCode} - ${response.reasonPhrase}');
+        developer.log('HTTP ${response.statusCode} - ${response.reasonPhrase}',
+            name: 'GVLService');
         return false;
       }
 
@@ -189,11 +192,13 @@ class GVLService {
       // Cache the data
       await _saveToCache(response.body, _cachedVersion!);
 
-      print(
-          'GVLService: Loaded ${_cachedVendors?.length ?? 0} vendors from remote (v$_cachedVersion)');
+      developer.log(
+          'Loaded ${_cachedVendors?.length ?? 0} vendors from remote (v$_cachedVersion)',
+          name: 'GVLService');
       return true;
     } catch (error) {
-      print('GVLService: Error fetching from remote - $error');
+      developer.log('Error fetching from remote',
+          error: error, name: 'GVLService');
       return false;
     }
   }
@@ -236,7 +241,8 @@ class GVLService {
         );
       }
     } catch (error) {
-      print('GVLService: Error parsing vendor list - $error');
+      developer.log('Error parsing vendor list',
+          error: error, name: 'GVLService');
     }
 
     return vendors;
@@ -251,7 +257,7 @@ class GVLService {
       await prefs.setInt(
           _cacheKeyGvlTimestamp, DateTime.now().millisecondsSinceEpoch);
     } catch (error) {
-      print('GVLService: Error saving to cache - $error');
+      developer.log('Error saving to cache', error: error, name: 'GVLService');
     }
   }
 }

--- a/test/model/vendor_info_test.dart
+++ b/test/model/vendor_info_test.dart
@@ -4,7 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('VendorInfo', () {
     test('constructor creates object with all properties', () {
-      final vendorInfo = VendorInfo(
+      const vendorInfo = VendorInfo(
         id: 755,
         name: 'Google LLC',
         consented: true,
@@ -20,7 +20,7 @@ void main() {
     });
 
     test('constructor works with minimal required parameters', () {
-      final vendorInfo = VendorInfo(
+      const vendorInfo = VendorInfo(
         id: 123,
         name: 'Test Vendor',
         consented: false,
@@ -35,7 +35,7 @@ void main() {
     });
 
     test('constructor works with empty purposes list', () {
-      final vendorInfo = VendorInfo(
+      const vendorInfo = VendorInfo(
         id: 456,
         name: 'Empty Purposes Vendor',
         consented: true,
@@ -165,7 +165,7 @@ void main() {
 
     group('toJson method', () {
       test('converts object to JSON with all fields', () {
-        final vendorInfo = VendorInfo(
+        const vendorInfo = VendorInfo(
           id: 755,
           name: 'Google LLC',
           consented: true,
@@ -183,7 +183,7 @@ void main() {
       });
 
       test('converts object to JSON with null description', () {
-        final vendorInfo = VendorInfo(
+        const vendorInfo = VendorInfo(
           id: 123,
           name: 'Test Vendor',
           consented: false,
@@ -200,7 +200,7 @@ void main() {
       });
 
       test('converts object with all fields to complete JSON', () {
-        final vendorInfo = VendorInfo(
+        const vendorInfo = VendorInfo(
           id: 755,
           name: 'Complete Vendor',
           consented: true,
@@ -231,7 +231,7 @@ void main() {
       });
 
       test('round-trip conversion maintains data integrity', () {
-        final original = VendorInfo(
+        const original = VendorInfo(
           id: 755,
           name: 'Google LLC',
           consented: true,
@@ -252,7 +252,7 @@ void main() {
 
     group('copyWith method', () {
       test('creates copy with updated fields', () {
-        final original = VendorInfo(
+        const original = VendorInfo(
           id: 755,
           name: 'Google LLC',
           consented: true,
@@ -275,7 +275,7 @@ void main() {
       });
 
       test('copyWith updates all optional fields', () {
-        final original = VendorInfo(
+        const original = VendorInfo(
           id: 1,
           name: 'Original Vendor',
           consented: true,
@@ -320,7 +320,7 @@ void main() {
       });
 
       test('creates exact copy when no parameters provided', () {
-        final original = VendorInfo(
+        const original = VendorInfo(
           id: 123,
           name: 'Test Vendor',
           consented: true,
@@ -337,7 +337,7 @@ void main() {
       });
 
       test('copies all fields when no parameters provided', () {
-        final original = VendorInfo(
+        const original = VendorInfo(
           id: 456,
           name: 'Has Description',
           consented: true,
@@ -355,26 +355,26 @@ void main() {
 
     group('equality and hashCode', () {
       test('objects with same values are equal', () {
-        final vendor1 = VendorInfo(
+        const vendor1 = VendorInfo(
           id: 755,
           name: 'Google LLC',
           consented: true,
           description: 'Google services',
           purposes: [1, 2, 3],
-          legitimateInterestPurposes: const [],
-          specialFeatures: const [],
-          specialPurposes: const [],
+          legitimateInterestPurposes: [],
+          specialFeatures: [],
+          specialPurposes: [],
         );
 
-        final vendor2 = VendorInfo(
+        const vendor2 = VendorInfo(
           id: 755,
           name: 'Google LLC',
           consented: true,
           description: 'Google services',
           purposes: [1, 2, 3],
-          legitimateInterestPurposes: const [],
-          specialFeatures: const [],
-          specialPurposes: const [],
+          legitimateInterestPurposes: [],
+          specialFeatures: [],
+          specialPurposes: [],
         );
 
         expect(vendor1, equals(vendor2));
@@ -387,14 +387,14 @@ void main() {
       });
 
       test('objects with different values are not equal', () {
-        final vendor1 = VendorInfo(
+        const vendor1 = VendorInfo(
           id: 755,
           name: 'Google LLC',
           consented: true,
           purposes: [1, 2, 3],
         );
 
-        final vendor2 = VendorInfo(
+        const vendor2 = VendorInfo(
           id: 756, // Different ID
           name: 'Google LLC',
           consented: true,
@@ -405,14 +405,14 @@ void main() {
       });
 
       test('objects with same null descriptions are equal', () {
-        final vendor1 = VendorInfo(
+        const vendor1 = VendorInfo(
           id: 123,
           name: 'Test',
           consented: false,
           purposes: [1],
         );
 
-        final vendor2 = VendorInfo(
+        const vendor2 = VendorInfo(
           id: 123,
           name: 'Test',
           consented: false,
@@ -423,14 +423,14 @@ void main() {
       });
 
       test('objects with different purpose lists are not equal', () {
-        final vendor1 = VendorInfo(
+        const vendor1 = VendorInfo(
           id: 123,
           name: 'Test',
           consented: true,
           purposes: [1, 2, 3],
         );
 
-        final vendor2 = VendorInfo(
+        const vendor2 = VendorInfo(
           id: 123,
           name: 'Test',
           consented: true,
@@ -443,7 +443,7 @@ void main() {
 
     group('toString method', () {
       test('provides readable string representation', () {
-        final vendorInfo = VendorInfo(
+        const vendorInfo = VendorInfo(
           id: 755,
           name: 'Google LLC',
           consented: true,
@@ -462,7 +462,7 @@ void main() {
       });
 
       test('handles null description in string representation', () {
-        final vendorInfo = VendorInfo(
+        const vendorInfo = VendorInfo(
           id: 123,
           name: 'Test',
           consented: false,
@@ -477,7 +477,7 @@ void main() {
 
     group('Real-world scenarios', () {
       test('handles typical TCF vendor data', () {
-        final vendorInfo = VendorInfo(
+        const vendorInfo = VendorInfo(
           id: 755,
           name: 'Google LLC',
           consented: true,
@@ -493,7 +493,7 @@ void main() {
       });
 
       test('handles vendor with no consent', () {
-        final vendorInfo = VendorInfo(
+        const vendorInfo = VendorInfo(
           id: 50,
           name: 'Criteo SA',
           consented: false,
@@ -504,7 +504,7 @@ void main() {
       });
 
       test('handles vendor with single purpose', () {
-        final vendorInfo = VendorInfo(
+        const vendorInfo = VendorInfo(
           id: 100,
           name: 'Single Purpose Vendor',
           consented: true,


### PR DESCRIPTION
## Summary
- Replace 9 print() statements with developer.log() in GVLService for structured logging with error context
- Fix const constructor performance issues in example/lib/vendor_screen.dart 
- Optimize 24 VendorInfo test constructors with const keywords for better test performance
- Remove unnecessary const keywords from list literals to eliminate warnings
- Achieve completely clean flutter analyze output: **35 → 0 issues** ✅
- Maintain full test coverage: **163/163 tests passing** ✅

## Test plan
- [x] Run `flutter analyze --no-fatal-infos` - No issues found
- [x] Run `flutter test` - All 163 tests passing
- [x] Verify pre-commit hooks pass (analyze, format, test)
- [x] Manual verification of logging improvements in GVLService
- [x] Confirm no functionality regression

🤖 Generated with [Claude Code](https://claude.ai/code)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Eliminated all Flutter analyzer info-level warnings (35 → 0) by switching GVLService to developer.log and correcting const usage across example and tests. No behavior changes; all tests pass (163/163).

- **Refactors**
  - Replaced nine print() calls with developer.log() in GVLService for structured logging with error context.
  - Fixed const placement in example/vendor_screen.dart (const Row; removed redundant const in children).
  - Marked VendorInfo test constructors as const and removed unnecessary const on list literals.

<!-- End of auto-generated description by cubic. -->

