### PR TITLE
feat(core): replace native SDKs with pure Flutter WebView implementation (MSK-90)

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
 
       - name: Install semantic-release dependencies
         run: |

--- a/.github/workflows/semver-release.yml
+++ b/.github/workflows/semver-release.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
 
       - name: Install semantic-release dependencies
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,19 @@
 ## 2.0.19
 
+### 🚨 Breaking Changes
+- Updated Android build environment:
+  - **Android Gradle Plugin:** 8.1.3  
+  - **Kotlin:** 2.1.0  
+  - **Gradle:** 8.1.3  
+  These updates require to update Flutter project's Android configuration accordingly.
+
 - Update iOS Axeptio SDK to 2.0.17
 - Update Android Axeptio SDK to 2.0.9
-- Enhanced: Application name now included in event metadata (MSK-73, MSK-74)
-- Improved: Network error handling with blocking view on iOS (MSK-98)
-- Fixed: iOS userAgent for native in-app events - WebView events now working correctly (MSK-109)
-- Fixed: Enhanced timeout mechanism on Android (MSK-102)
-- Fixed: Additional iOS improvements (MSK-111)
+- Enhanced: Application name now included in event metadata
+- Improved: Network error handling with blocking view on iOS
+- Fixed: iOS userAgent for native in-app events - WebView events now working correctly
+- Fixed: Enhanced timeout mechanism on Android
+- Fixed: Additional iOS improvements
 
 ## 2.0.18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.19
+
+- Update iOS Axeptio SDK to 2.0.17
+- Update Android Axeptio SDK to 2.0.9
+- Enhanced: Application name now included in event metadata (MSK-73, MSK-74)
+- Improved: Network error handling with blocking view on iOS (MSK-98)
+- Fixed: iOS userAgent for native in-app events - WebView events now working correctly (MSK-109)
+- Fixed: Enhanced timeout mechanism on Android (MSK-102)
+- Fixed: Additional iOS improvements (MSK-111)
+
 ## 2.0.18
 
 ### ✨ New Features
@@ -63,7 +73,7 @@
 - Add comprehensive TCF vendor consent management APIs (iOS & Android).
   - `getVendorConsents()`: Get all vendor consents as Map<int, bool>
   - `getConsentedVendors()`: Get list of consented vendor IDs
-  - `getRefusedVendors()`: Get list of refused vendor IDs  
+  - `getRefusedVendors()`: Get list of refused vendor IDs
   - `isVendorConsented(vendorId)`: Check specific vendor consent status
 - Add extensive README documentation with TCF vendor management examples.
 - Add TCF vendor consent demo in example app with detailed logging.
@@ -135,7 +145,7 @@ Fix CMP first show on iOS SDK
 ## 1.2.0
 
 * First release
-  
+
 ## 1.0.0-alpha2
 
 * Second alpha

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,19 @@
-## 2.0.19
+## 3.0.0
 
 ### 🚨 Breaking Changes
-- Updated Android build environment:
-  - **Android Gradle Plugin:** 8.1.3  
-  - **Kotlin:** 2.1.0  
-  - **Gradle:** 8.1.3  
-  These updates require to update Flutter project's Android configuration accordingly.
 
-- Update iOS Axeptio SDK to 2.0.17
-- Update Android Axeptio SDK to 2.0.9
-- Enhanced: Application name now included in event metadata
-- Improved: Network error handling with blocking view on iOS
-- Fixed: iOS userAgent for native in-app events - WebView events now working correctly
-- Fixed: Enhanced timeout mechanism on Android
-- Fixed: Additional iOS improvements
+- **`navigatorKey` is now required** for the consent UI to function. Set it before calling
+  `initialize`:
+  ```dart
+  AxeptioSdk.navigatorKey = GlobalKey<NavigatorState>();
+  // Pass it to MaterialApp:
+  MaterialApp(navigatorKey: AxeptioSdk.navigatorKey, ...)
+  ```
+- Native iOS and Android Axeptio SDKs have been **removed**. Consent is now managed entirely
+  through a pure Flutter WebView implementation. No Maven credentials or CocoaPods setup is
+  required.
+- The `_ax_token` SharedPreferences key is replaced by `AX_CLIENT_TOKEN`. Existing stored tokens
+  are read transparently during migration.
 
 ## 2.0.18
 

--- a/README.md
+++ b/README.md
@@ -250,9 +250,7 @@ print('Brand keys: ${NativeDefaultPreferences.brandKeys}');
 print('TCF keys: ${NativeDefaultPreferences.tcfKeys}');
 print('All supported keys: ${NativeDefaultPreferences.allKeys}');
 ```
-> ⚠️ **Note for Android:** On Android, the SDK stores consent data in native preferences.
-> Using `SharedPreferences.getInstance()` may return `null` if the consent popup was not accepted or if the storage is not shared with Flutter.
-> For reliable results, use `NativeDefaultPreferences.getDefaultPreference()` instead.
+> ℹ️ **Note:** Consent data is stored via Flutter's `shared_preferences` and is directly accessible using `getConsentSavedData()`.
 
 <br><br><br>
 ## TCF (Transparency & Consent Framework) Vendor Management
@@ -638,7 +636,7 @@ The Axeptio Flutter SDK includes comprehensive test coverage to ensure reliabili
 ### Current Test Coverage
 - **Coverage**: 97.6% (lines covered)
 - **Target**: 95% coverage requirement (current: 97.6%)
-- **Tests**: 85 comprehensive tests
+- **Tests**: 302 comprehensive tests
 - **Status**: ✅ Coverage meets target
 
 [![Test Coverage](https://img.shields.io/badge/coverage-97.6%25-brightgreen)](TESTING.md)

--- a/README.md
+++ b/README.md
@@ -636,12 +636,12 @@ Future<Map<int, String>> safeGetVendorNames(List<int> vendorIds) async {
 The Axeptio Flutter SDK includes comprehensive test coverage to ensure reliability and catch regressions.
 
 ### Current Test Coverage
-- **Coverage**: 58.9% (122/207 lines covered)
-- **Target**: 95% coverage requirement
+- **Coverage**: 97.6% (lines covered)
+- **Target**: 95% coverage requirement (current: 97.6%)
 - **Tests**: 85 comprehensive tests
-- **Status**: ⚠️ Coverage below target - improvement in progress
+- **Status**: ✅ Coverage meets target
 
-[![Test Coverage](https://img.shields.io/badge/coverage-58.9%25-orange)](TESTING.md)
+[![Test Coverage](https://img.shields.io/badge/coverage-97.6%25-brightgreen)](TESTING.md)
 
 ### Quick Testing Commands
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,22 @@ Alternatively, you can manually add the dependency to your `pubspec.yaml` under 
 dependencies:
   flutter:
     sdk: flutter
-  axeptio_sdk: ^2.0.19
+  axeptio_sdk: ^3.0.0
+```
+
+### Navigator Key Setup
+The SDK presents its consent UI by pushing a route onto your app's navigator. You must provide a
+`GlobalKey<NavigatorState>` before calling `initialize`:
+
+```dart
+// 1. Declare the key (top-level or in your app widget):
+AxeptioSdk.navigatorKey = GlobalKey<NavigatorState>();
+
+// 2. Pass it to MaterialApp:
+MaterialApp(
+  navigatorKey: AxeptioSdk.navigatorKey,
+  // ...
+)
 ```
 
 ### Android Setup
@@ -63,77 +78,8 @@ android {
     }
 }
 ```
-##### Add Maven Repository and Credentials
-In order to download and include the Axeptio SDK, you'll need to configure the Maven repository and authentication credentials in your `android/build.gradle` file. Follow these steps:
-1. Open the `android/build.gradle` file in your Flutter project.
-2. In the `repositories block`, add the Axeptio Maven repository URL and the required credentials for authentication.
 
-Here is the necessary configuration to add:
-```gradle
-allprojects {
-    repositories {
-        google()
-        mavenCentral()
-        maven {
-            url = uri("https://maven.pkg.github.com/axeptio/axeptio-android-sdk")
-            credentials {
-                username = System.getenv("GITHUB_USERNAME") ?: project.findProperty("github.username") as String? ?: ""
-                password = System.getenv("GITHUB_TOKEN") ?: project.findProperty("github.token") as String? ?: ""
-            }
-        }
-    }
-}
-```
-##### GitHub Authentication & Security Setup
-
-⚠️ **SECURITY CRITICAL**: Never hardcode credentials in your build files or commit them to version control.
-
-**Step 1: Generate GitHub Token**
-1. Visit GitHub and navigate to **Settings > Developer settings > Personal access tokens**.
-2. Click **Generate new token** and select permissions (minimum: `read:packages`).
-3. Copy the generated token immediately (you won't see it again).
-
-**Step 2: Configure Environment Variables**
-Set up your credentials using **environment variables** (recommended) or **gradle.properties**:
-
-**Option A: Environment Variables (Recommended)**
-```bash
-export GITHUB_USERNAME=your_github_username
-export GITHUB_TOKEN=your_generated_token
-```
-
-**Option B: gradle.properties (Alternative)**
-Create `~/.gradle/gradle.properties` or `android/gradle.properties`:
-```properties
-github.username=your_github_username
-github.token=your_generated_token
-```
-
-**Step 3: Update .gitignore**
-Ensure your `.gitignore` includes:
-```gitignore
-# Gradle credentials
-gradle.properties
-local.properties
-```
-
-> **🔒 Security Best Practices:**
-> - Never commit credentials to version control
-> - Rotate tokens regularly (quarterly recommended)
-> - Use minimal required permissions
-> - Consider using CI/CD environment variables for builds
-
-##### Sync Gradle
-Once you've added the repository and credentials, sync your Gradle files by either running:
-```bash
-flutter pub get
-```
-Or manually through Android Studio by clicking **File > Sync Project** with Gradle Files.
-
-This will allow your project to fetch the necessary dependencies from the Axeptio Maven repository.
-
-> **🏭 Production Deployment Notice:**
-> For production builds, ensure you have configured CI/CD environment variables and never include credentials in your app bundle. Consider using build flavors for different environments.
+No additional Maven repository or credentials are required — the SDK is published on pub.dev.
 
 ### iOS Setup
 ##### Minimum iOS Version

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repository demonstrates the integration of the **Axeptio Flutter SDK** into
 12. [Testing and Development](#testing-and-development)
 13. [Local Test](#local-test)
 <br><br><br>
-## Setup and Installation   
+## Setup and Installation
 To integrate the Axeptio SDK into your Flutter project, run the following command in your terminal:
 ```bash
 flutter pub add axeptio_sdk
@@ -50,7 +50,7 @@ Alternatively, you can manually add the dependency to your `pubspec.yaml` under 
 dependencies:
   flutter:
     sdk: flutter
-  axeptio_sdk: ^2.0.18
+  axeptio_sdk: ^2.0.19
 ```
 
 ### Android Setup
@@ -119,7 +119,7 @@ local.properties
 
 > **🔒 Security Best Practices:**
 > - Never commit credentials to version control
-> - Rotate tokens regularly (quarterly recommended)  
+> - Rotate tokens regularly (quarterly recommended)
 > - Use minimal required permissions
 > - Consider using CI/CD environment variables for builds
 
@@ -190,7 +190,7 @@ In your iOS project, add the following key to `Info.plist` to explain why the ap
 flutter pub add app_tracking_transparency
 ```
 3. **Request Tracking Authorization:**
-Use the **AppTrackingTransparency** plugin to request permission before initializing the **Axeptio SDK's** consent UI. The flow checks the user’s status and takes appropriate actions based on their choice. 
+Use the **AppTrackingTransparency** plugin to request permission before initializing the **Axeptio SDK's** consent UI. The flow checks the user’s status and takes appropriate actions based on their choice.
 ```dart
 try {
   TrackingStatus status = await AppTrackingTransparency.trackingAuthorizationStatus;
@@ -219,24 +219,24 @@ The Axeptio SDK and your mobile application each have distinct responsibilities 
 
 #### Mobile App Responsibilities:
 
-1. **Implementing ATT Flow**  
+1. **Implementing ATT Flow**
    Your app must handle the App Tracking Transparency (ATT) permission request and manage the display of the ATT prompt at the appropriate time relative to the Axeptio CMP.
 
-2. **Privacy Declaration**  
+2. **Privacy Declaration**
    The app must declare data collection practices accurately in App Store privacy labels.
 
-3. **Handling SDK Events**  
+3. **Handling SDK Events**
    The app should listen for events triggered by the SDK and adjust its behavior based on user consent status.
 
 #### Axeptio SDK Responsibilities:
 
-1. **Consent Management UI**  
+1. **Consent Management UI**
    The SDK is responsible for displaying the consent management interface.
 
-2. **Storing and Managing User Consent**  
+2. **Storing and Managing User Consent**
    It stores and manages consent choices across sessions.
 
-3. **API Integration**  
+3. **API Integration**
    The SDK communicates user consent status through its API endpoints.
 
 **Note:** The SDK does not manage ATT permissions. You must handle this separately as shown above.
@@ -275,7 +275,7 @@ final allVendors = await NativeDefaultPreferences.getDefaultPreference('axeptio_
 final authorizedVendors = await NativeDefaultPreferences.getDefaultPreference('axeptio_authorized_vendors');
 ```
 
-##### TCF Keys  
+##### TCF Keys
 ```dart
 // Access TCF (Transparency & Consent Framework) data
 final tcString = await NativeDefaultPreferences.getDefaultPreference('IABTCF_TCString');
@@ -304,7 +304,7 @@ print('Brand keys: ${NativeDefaultPreferences.brandKeys}');
 print('TCF keys: ${NativeDefaultPreferences.tcfKeys}');
 print('All supported keys: ${NativeDefaultPreferences.allKeys}');
 ```
-> ⚠️ **Note for Android:** On Android, the SDK stores consent data in native preferences. 
+> ⚠️ **Note for Android:** On Android, the SDK stores consent data in native preferences.
 > Using `SharedPreferences.getInstance()` may return `null` if the consent popup was not accepted or if the storage is not shared with Flutter.
 > For reliable results, use `NativeDefaultPreferences.getDefaultPreference()` instead.
 
@@ -383,7 +383,7 @@ print('Apple consent: ${appleConsent ? "✅ Granted" : "❌ Refused"}');
 Future<void> loadFeatureBasedOnConsent() async {
   // Check if advertising vendor has consent
   bool adConsentGranted = await axeptioSdk.isVendorConsented(50);
-  
+
   if (adConsentGranted) {
     // Load advertising SDK
     await initializeAdvertisingSDK();
@@ -400,22 +400,22 @@ Future<void> analyzeVendorConsents() async {
   Map<int, bool> allConsents = await axeptioSdk.getVendorConsents();
   List<int> consented = await axeptioSdk.getConsentedVendors();
   List<int> refused = await axeptioSdk.getRefusedVendors();
-  
+
   // Calculate consent statistics
   double consentRate = consented.length / allConsents.length;
-  
+
   print('📊 Consent Analytics:');
   print('Total vendors: ${allConsents.length}');
   print('Consented: ${consented.length}');
   print('Refused: ${refused.length}');
   print('Consent rate: ${(consentRate * 100).toStringAsFixed(1)}%');
-  
+
   // Log specific vendor categories
   List<int> adTechVendors = [1, 2, 50, 100]; // Example ad tech vendor IDs
   List<int> consentedAdTech = adTechVendors.where(
     (id) => consented.contains(id)
   ).toList();
-  
+
   print('Ad Tech vendors consented: $consentedAdTech');
 }
 ```
@@ -427,15 +427,15 @@ Widget buildVendorConsentList() {
     future: axeptioSdk.getVendorConsents(),
     builder: (context, snapshot) {
       if (!snapshot.hasData) return CircularProgressIndicator();
-      
+
       final vendorConsents = snapshot.data!;
-      
+
       return ListView.builder(
         itemCount: vendorConsents.length,
         itemBuilder: (context, index) {
           final vendorId = vendorConsents.keys.elementAt(index);
           final isConsented = vendorConsents[vendorId]!;
-          
+
           return ListTile(
             title: Text('Vendor $vendorId'),
             trailing: Icon(
@@ -460,7 +460,7 @@ Future<void> safeVendorConsentCheck() async {
   try {
     // APIs return empty collections on error (never null)
     Map<int, bool> consents = await axeptioSdk.getVendorConsents();
-    
+
     if (consents.isEmpty) {
       print('No vendor consent data available');
       // Handle case where no consent data exists
@@ -479,7 +479,7 @@ Future<void> safeVendorConsentCheck() async {
 | Method | iOS | Android |
 |--------|-----|---------|
 | `getVendorConsents()` | ✅ Available | ✅ Available |
-| `getConsentedVendors()` | ✅ Available | ✅ Available |  
+| `getConsentedVendors()` | ✅ Available | ✅ Available |
 | `getRefusedVendors()` | ✅ Available | ✅ Available |
 | `isVendorConsented()` | ✅ Available | ✅ Available |
 
@@ -498,10 +498,10 @@ This is useful if you want to show the popup at a specific moment based on app f
 For **publishers**, the SDK provides a feature to share the user's consent status with web views by appending the **Axeptio token** as a query parameter.
 ```dart
 final token = await axeptioSdk.axeptioToken;
-final url = await axeptioSdk.appendAxeptioTokenURL(  
-  "https://myurl.com",  
-  token,  
-); 
+final url = await axeptioSdk.appendAxeptioTokenURL(
+  "https://myurl.com",
+  token,
+);
 // Will return: https://myurl.com?axeptio_token=[token]
 ```
 This feature ensures that consent status is properly communicated across different parts of the application, including web content.
@@ -559,13 +559,13 @@ This tagging is handled automatically by the native SDK components used under th
 
 The Axeptio SDK provides comprehensive **Global Vendor List (GVL) integration** for resolving TCF vendor IDs to human-readable vendor names. This feature bridges the gap between numeric vendor IDs and user-friendly vendor information.
 
-> 📱 **Platform Support**: Available on **both iOS and Android** platforms.  
+> 📱 **Platform Support**: Available on **both iOS and Android** platforms.
 > 🌐 **Data Source**: Fetches from the official IAB Global Vendor List API
 
 ### Key Features
 
 - **🔄 Automatic Caching**: 7-day intelligent caching with background refresh
-- **⚡ High Performance**: Optimized memory usage and fast lookups  
+- **⚡ High Performance**: Optimized memory usage and fast lookups
 - **🌐 Offline Support**: Graceful fallback when network unavailable
 - **🎯 Flexible APIs**: Individual and bulk vendor name resolution
 - **🛡️ Error Handling**: Robust error handling with fallback mechanisms
@@ -648,7 +648,7 @@ Control GVL caching behavior for optimal performance:
 final isLoaded = await axeptioSdk.isGVLLoaded();
 print('GVL loaded: $isLoaded');
 
-// Get current GVL version  
+// Get current GVL version
 final version = await axeptioSdk.getGVLVersion();
 print('Current GVL version: ${version ?? "Not loaded"}');
 
@@ -671,7 +671,7 @@ Future<Map<int, String>> safeGetVendorNames(List<int> vendorIds) async {
         return <int, String>{}; // Return empty map on failure
       }
     }
-    
+
     return await axeptioSdk.getVendorNames(vendorIds);
   } catch (e) {
     print('Error getting vendor names: $e');
@@ -687,11 +687,11 @@ Future<Map<int, String>> safeGetVendorNames(List<int> vendorIds) async {
 
 ## Testing and Development
 
-The Axeptio Flutter SDK includes comprehensive test coverage to ensure reliability and catch regressions. 
+The Axeptio Flutter SDK includes comprehensive test coverage to ensure reliability and catch regressions.
 
 ### Current Test Coverage
 - **Coverage**: 58.9% (122/207 lines covered)
-- **Target**: 95% coverage requirement 
+- **Target**: 95% coverage requirement
 - **Tests**: 85 comprehensive tests
 - **Status**: ⚠️ Coverage below target - improvement in progress
 
@@ -715,7 +715,7 @@ flutter test test/preferences/
 ### Test Structure
 Our test suite is organized into logical components:
 - **Core SDK Tests**: Initialization, UI management, consent handling
-- **Method Channel Tests**: Platform communication and vendor consent APIs  
+- **Method Channel Tests**: Platform communication and vendor consent APIs
 - **Event System Tests**: Event listeners and callback handling
 - **Model Tests**: Data validation and type conversion
 - **Native Preferences Tests**: Cross-platform preference access
@@ -741,7 +741,7 @@ For detailed testing information, patterns, and coverage improvement strategies,
 - Checkout the master branch.
 
 ### Change native SDK version
-#### Android 
+#### Android
 In `android/build.gradle`, update the dependencies:
 ```gradle
 dependencies {
@@ -765,7 +765,7 @@ Pod::Spec.new do |s|
   s.platform = :ios, '15.0'
 ```
 
-### ⚙️Configure widget in sample app 
+### ⚙️Configure widget in sample app
 To configure the widget, add the project ID and version name in `example/lib/main.dart`:
 ```dart
   Future<void> initSDK() async {

--- a/README.md
+++ b/README.md
@@ -442,11 +442,13 @@ This is useful if you want to show the popup at a specific moment based on app f
 For **publishers**, the SDK provides a feature to share the user's consent status with web views by appending the **Axeptio token** as a query parameter.
 ```dart
 final token = await axeptioSdk.axeptioToken;
-final url = await axeptioSdk.appendAxeptioTokenURL(
-  "https://myurl.com",
-  token,
-);
-// Will return: https://myurl.com?axeptio_token=[token]
+if (token != null) {
+  final url = await axeptioSdk.appendAxeptioTokenURL(
+    "https://myurl.com",
+    token,
+  );
+  // Will return: https://myurl.com?axeptio_token=[token]
+}
 ```
 This feature ensures that consent status is properly communicated across different parts of the application, including web content.
 <br><br><br>

--- a/TESTING.md
+++ b/TESTING.md
@@ -5,10 +5,10 @@ This document provides comprehensive guidance for testing the Axeptio Flutter SD
 ## 📊 Test Coverage Requirements
 
 ### Current Status
-- **Current Coverage**: 58.9% (122/207 lines covered)
+- **Current Coverage**: 97.6%
 - **Target Coverage**: 95% (as specified in [CLAUDE.md](CLAUDE.md))
-- **Total Tests**: 85 comprehensive tests
-- **Status**: ⚠️ **Coverage Below Target** - requires improvement
+- **Total Tests**: 301 comprehensive tests
+- **Status**: ✅ **Coverage Meets Target**
 
 ### Coverage by Component
 | Component | Coverage | Lines Covered | Status |
@@ -120,7 +120,7 @@ flutter test --coverage && awk '
 BEGIN { total_lines = 0; hit_lines = 0 }
 /^LF:/ { total_lines += substr($0, 4) }
 /^LH:/ { hit_lines += substr($0, 4) }
-END { 
+END {
     coverage = (total_lines > 0) ? (hit_lines * 100.0 / total_lines) : 0
     printf "Overall Coverage: %.1f%%\n", coverage
 }' coverage/lcov.info
@@ -129,7 +129,7 @@ END {
 ## 🎯 Coverage Improvement Roadmap
 
 ### Priority 1: Critical Coverage Issues (0-34%)
-1. **`events/event_listener.dart` (0%)**: 
+1. **`events/event_listener.dart` (0%)**:
    - Add tests for default callback initialization
    - Test callback reassignment functionality
    - Validate callback execution patterns
@@ -167,26 +167,26 @@ END {
 class MockAxeptioSdkPlatform
     with MockPlatformInterfaceMixin
     implements AxeptioSdkPlatform {
-  
+
   // State management
   bool _isInitialized = false;
   AxeptioService? _currentService;
   final List<AxeptioEventListener> _listeners = [];
-  
+
   // Mock data with realistic values
   final Map<String, dynamic> _mockConsentData = {
     'axeptio_cookies': '{"analytics": true, "ads": false}',
     'IABTCF_TCString': 'CPXxRfAPXxRfAAfKABENATEIAAIAAAAAAAAAAAAA',
     'IABTCF_gdprApplies': '1',
   };
-  
+
   // Helper methods for testing
   void reset() {
     _isInitialized = false;
     _currentService = null;
     _listeners.clear();
   }
-  
+
   void setMockData(Map<String, dynamic> data) {
     _mockConsentData.clear();
     _mockConsentData.addAll(data);
@@ -211,10 +211,10 @@ group('Component Name', () {
     test('specific behavior description', () async {
       // Arrange
       mockPlatform.setExpectedData(data);
-      
+
       // Act
       final result = await component.method();
-      
+
       // Assert
       expect(result, expectedValue);
       expect(mockPlatform.wasMethodCalled, isTrue);
@@ -227,9 +227,9 @@ group('Component Name', () {
 ```dart
 test('handles platform exceptions gracefully', () async {
   mockPlatform.setShouldThrowError(true);
-  
+
   final result = await component.methodThatMightFail();
-  
+
   expect(result, isNull); // or appropriate default
 });
 ```
@@ -238,9 +238,9 @@ test('handles platform exceptions gracefully', () async {
 ```dart
 test('async operations complete successfully', () async {
   final future = component.asyncMethod();
-  
+
   await expectLater(future, completes);
-  
+
   final result = await future;
   expect(result, isNotNull);
 });
@@ -319,7 +319,7 @@ fi
 - [ ] Async operation testing (if applicable)
 - [ ] State management testing (if applicable)
 
-### For Bug Fixes  
+### For Bug Fixes
 - [ ] Regression test that reproduces the original bug
 - [ ] Test that verifies the fix works
 - [ ] Edge cases related to the bug scenario
@@ -349,13 +349,13 @@ jobs:
       - uses: subosito/flutter-action@v2
         with:
           flutter-version: '3.3.0'
-      
+
       - name: Install dependencies
         run: flutter pub get
-      
+
       - name: Run tests with coverage
         run: flutter test --coverage
-      
+
       - name: Check coverage threshold
         run: |
           # Script to check coverage meets 95% requirement

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,6 @@ android {
     }
 
     dependencies {
-        implementation("io.axept.android:android-sdk:2.0.9")
         implementation("androidx.preference:preference-ktx:1.2.1")
 
         testImplementation 'org.jetbrains.kotlin:kotlin-test'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ android {
     }
 
     dependencies {
-        implementation("io.axept.android:android-sdk:2.0.8")
+        implementation("io.axept.android:android-sdk:2.0.9")
         implementation("androidx.preference:preference-ktx:1.2.1")
 
         testImplementation 'org.jetbrains.kotlin:kotlin-test'

--- a/android/src/main/kotlin/io/axept/axeptio_sdk/AxeptioEventStreamHandler.kt
+++ b/android/src/main/kotlin/io/axept/axeptio_sdk/AxeptioEventStreamHandler.kt
@@ -1,46 +1,9 @@
 package io.axept.axeptio_sdk
 
-import io.axept.android.googleconsent.GoogleConsentStatus
-import io.axept.android.googleconsent.GoogleConsentType
-import io.axept.android.library.AxeptioEventListener
-import io.axept.android.library.AxeptioSDK
 import io.flutter.plugin.common.EventChannel
 
-
+/** No-op stream handler — events are emitted by the Flutter WebView layer. */
 object AxeptioEventStreamHandler : EventChannel.StreamHandler {
-
-    private var axeptioEventListener: AxeptioEventListener? = null
-
-    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {
-        axeptioEventListener = object : AxeptioEventListener {
-
-            override fun onPopupClosedEvent() {
-                super.onPopupClosedEvent()
-                events?.success(hashMapOf("type" to "onPopupClosedEvent"))
-            }
-
-            override fun onGoogleConsentModeUpdate(consentMap: Map<GoogleConsentType, GoogleConsentStatus>) {
-                super.onGoogleConsentModeUpdate(consentMap)
-                val event = hashMapOf<String, Any>()
-                event["type"] = "onGoogleConsentModeUpdate"
-                event["googleConsentV2"] = mapOf(
-                    "analyticsStorage" to (consentMap[GoogleConsentType.ANALYTICS_STORAGE] == GoogleConsentStatus.GRANTED),
-                    "adStorage" to (consentMap[GoogleConsentType.AD_STORAGE] == GoogleConsentStatus.GRANTED),
-                    "adUserData" to (consentMap[GoogleConsentType.AD_USER_DATA] == GoogleConsentStatus.GRANTED),
-                    "adPersonalization" to (consentMap[GoogleConsentType.AD_PERSONALIZATION] == GoogleConsentStatus.GRANTED),
-                )
-                events?.success(event)
-            }
-
-            override fun onConsentCleared() {
-                super.onConsentCleared()
-                events?.success(hashMapOf("type" to "onConsentCleared"))
-            }
-        }
-        axeptioEventListener?.let { AxeptioSDK.instance().setEventListener(it) }
-    }
-
-    override fun onCancel(arguments: Any?) {
-        axeptioEventListener = null
-    }
+    override fun onListen(arguments: Any?, events: EventChannel.EventSink?) {}
+    override fun onCancel(arguments: Any?) {}
 }

--- a/android/src/main/kotlin/io/axept/axeptio_sdk/AxeptioSdkPlugin.kt
+++ b/android/src/main/kotlin/io/axept/axeptio_sdk/AxeptioSdkPlugin.kt
@@ -1,9 +1,6 @@
 package io.axept.axeptio_sdk
 
 import android.app.Activity
-import android.net.Uri
-import io.axept.android.library.AxeptioSDK
-import io.axept.android.library.AxeptioService
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
 import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
@@ -13,7 +10,7 @@ import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
 
-/** AxeptioSdkPlugin */
+/** AxeptioSdkPlugin — stub implementation; consent is handled by the Flutter WebView layer. */
 class AxeptioSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
     private lateinit var channel: MethodChannel
     private var activity: Activity? = null
@@ -46,134 +43,8 @@ class AxeptioSdkPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
 
     override fun onMethodCall(call: MethodCall, result: Result) {
         when (call.method) {
-            "getPlatformVersion" -> {
-                result.success("Android ${android.os.Build.VERSION.RELEASE}")
-            }
-            "initialize" -> {
-                val arguments =
-                        call.arguments?.let { it as? HashMap<String, Any> }
-                                ?: run {
-                                    result.error(
-                                            "invalid_args",
-                                            "Wrong arguments for initialize",
-                                            null
-                                    )
-                                    return
-                                }
-
-                val clientId = arguments.get("clientId") as String
-                val cookiesVersion = arguments.get("cookiesVersion") as String
-                val token = arguments.get("token") as? String?
-                val targetService = arguments.get("targetService") as String
-                val axeptioService =
-                        when (targetService) {
-                            "brands" -> AxeptioService.BRANDS
-                            "publishers" -> AxeptioService.PUBLISHERS_TCF
-                            else -> AxeptioService.PUBLISHERS_TCF
-                        }
-
-                AxeptioSDK.instance()
-                        .initialize(activity!!, axeptioService, clientId, cookiesVersion, token)
-
-                result.success(null)
-            }
-            "showConsentScreen" -> {
-                AxeptioSDK.instance().showConsentScreen(activity!!, true)
-                result.success(null)
-            }
-            "axeptioToken" -> {
-                result.success(AxeptioSDK.instance().token)
-            }
-            "appendAxeptioTokenURL" -> {
-                val arguments =
-                        call.arguments?.let { it as? HashMap<String, Any> }
-                                ?: run {
-                                    result.error(
-                                            "invalid_args",
-                                            "Wrong arguments for appendAxeptioTokenURL",
-                                            null
-                                    )
-                                    return
-                                }
-
-                val urlStr = arguments.get("url") as String
-                val uri = Uri.parse(urlStr)
-                val token = arguments.get("token") as String
-
-                val response = AxeptioSDK.instance().appendAxeptioToken(uri = uri, token = token)
-                result.success(response.toString())
-            }
-            "clearConsent" -> {
-                AxeptioSDK.instance().clearConsents()
-                result.success(null)
-            }
-            "getConsentSavedData" -> {
-                val preferenceKey = call.argument<String>("preferenceKey")
-                val response = AxeptioSDK.instance().getConsentDebugInfo(preferenceKey)
-                val safeResponse = sanitizeForFlutter(response)
-                result.success(safeResponse)
-            }
-            "getConsentDebugInfo" -> {
-                val preferenceKey = call.argument<String>("preferenceKey")
-                val response = AxeptioSDK.instance().getConsentDebugInfo(preferenceKey)
-                val safeResponse = sanitizeForFlutter(response)
-                result.success(safeResponse)
-            }
-            "getVendorConsents" -> {
-                val vendorConsents = AxeptioSDK.instance().getVendorConsents()
-                val safeResponse = sanitizeForFlutter(vendorConsents)
-                result.success(safeResponse)
-            }
-            "getConsentedVendors" -> {
-                val consentedVendors = AxeptioSDK.instance().getConsentedVendors()
-                val safeResponse = sanitizeForFlutter(consentedVendors)
-                result.success(safeResponse)
-            }
-            "getRefusedVendors" -> {
-                val refusedVendors = AxeptioSDK.instance().getRefusedVendors()
-                val safeResponse = sanitizeForFlutter(refusedVendors)
-                result.success(safeResponse)
-            }
-            "isVendorConsented" -> {
-                val vendorId = call.argument<Int>("vendorId")
-                if (vendorId != null) {
-                    val isConsented = AxeptioSDK.instance().isVendorConsented(vendorId)
-                    result.success(isConsented)
-                } else {
-                    result.error("invalid_args", "isVendorConsented: Missing argument 'vendorId'", null)
-                }
-            }
-
-
-            // iOS specific
-            "setupUI",
-            "setUserDeniedTracking" -> {
-                result.success(null)
-            }
-            else -> {
-                result.notImplemented()
-            }
-        }
-    }
-
-    fun sanitizeForFlutter(value: Any?): Any? {
-        return when (value) {
-            null, is Boolean, is Int, is Long, is Double, is String, is ByteArray -> value
-            is java.util.Date ->
-                    java.time.format.DateTimeFormatter.ISO_INSTANT.format(
-                            value.toInstant()
-                    ) // convert Date to ISO string
-            is android.net.Uri -> value.toString() // convert Uri to string
-            is List<*> -> value.mapNotNull { sanitizeForFlutter(it) }
-            is Map<*, *> -> {
-                val safeMap = mutableMapOf<String, Any?>()
-                value.forEach { (k, v) ->
-                    val key = k?.toString() ?: "null"
-                    safeMap[key] = sanitizeForFlutter(v)
-                }
-                safeMap
-            }
-            else -> value.toString() // fallback for any unsupported type
+            "getPlatformVersion" -> result.success("Android ${android.os.Build.VERSION.RELEASE}")
+            else -> result.notImplemented()
         }
     }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ if (flutterVersionName == null) {
 android {
     namespace "io.axept.axeptio_sdk_example"
     compileSdk 35
-    ndkVersion flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -25,7 +25,7 @@ if (flutterVersionName == null) {
 android {
     namespace "io.axept.axeptio_sdk_example"
     compileSdk 35
-    ndkVersion = "27.0.12077973"
+    ndkVersion = flutter.ndkVersion
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -19,8 +19,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version '8.5.0' apply false
-    id "org.jetbrains.kotlin.android" version "1.9.10" apply false
+    id "com.android.application" version '8.13.0' apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1,10 +1,10 @@
 PODS:
   - app_tracking_transparency (0.0.1):
     - Flutter
-  - axeptio_sdk (2.0.15):
-    - AxeptioIOSSDK (= 2.0.15)
+  - axeptio_sdk (2.0.17):
+    - AxeptioIOSSDK (= 2.0.17)
     - Flutter
-  - AxeptioIOSSDK (2.0.15)
+  - AxeptioIOSSDK (2.0.17)
   - Flutter (1.0.0)
   - Google-Mobile-Ads-SDK (11.13.0):
     - GoogleUserMessagingPlatform (>= 1.1)
@@ -55,9 +55,9 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   app_tracking_transparency: 3d84f147f67ca82d3c15355c36b1fa6b66ca7c92
-  axeptio_sdk: 95a588cf05b9c21b513937c204514f835a4a2d3c
-  AxeptioIOSSDK: 1ad235e891b6ce15bc8b9b24b8a76da9548b5201
-  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  axeptio_sdk: 2021521a8320f841a434b93422ae565f17ed7125
+  AxeptioIOSSDK: 578c5f09244f6afef38636baa4842e38fbfad89a
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   Google-Mobile-Ads-SDK: 14f57f2dc33532a24db288897e26494640810407
   google_mobile_ads: 16ad301354fa6a7ea55770c6254bd4339bf8558b
   GoogleUserMessagingPlatform: f8d0cdad3ca835406755d0a69aa634f00e76d576

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
+      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
       url: "https://pub.dev"
     source: hosted
-    version: "2.13.0"
+    version: "2.12.0"
   axeptio_sdk:
     dependency: "direct main"
     description:
@@ -68,10 +68,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -154,26 +154,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.1"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -375,10 +375,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   typed_data:
     dependency: transitive
     description:
@@ -391,18 +391,18 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
+      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
       url: "https://pub.dev"
     source: hosted
-    version: "15.0.0"
+    version: "14.3.1"
   web:
     dependency: transitive
     description:
@@ -415,10 +415,10 @@ packages:
     dependency: transitive
     description:
       name: webdriver
-      sha256: "2f3a14ca026957870cfd9c635b83507e0e51d8091568e90129fbf805aba7cade"
+      sha256: "3d773670966f02a646319410766d3b5e1037efb7f07cc68f844d5e06cd4d61c8"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.0.4"
   webview_flutter:
     dependency: "direct main"
     description:
@@ -460,5 +460,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.7.2 <4.0.0"
   flutter: ">=3.27.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.19"
+    version: "3.0.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -23,7 +23,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.18"
+    version: "2.0.19"
   boolean_selector:
     dependency: transitive
     description:
@@ -68,10 +68,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -154,26 +154,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -375,10 +375,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.4"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -391,10 +391,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -460,5 +460,5 @@ packages:
     source: hosted
     version: "1.1.0"
 sdks:
-  dart: ">=3.7.2 <4.0.0"
+  dart: ">=3.8.0-0 <4.0.0"
   flutter: ">=3.27.0"

--- a/ios/Classes/AxeptioEventStreamHandler.swift
+++ b/ios/Classes/AxeptioEventStreamHandler.swift
@@ -1,53 +1,14 @@
 import Flutter
-import AxeptioSDK
 
+/// No-op stream handler — events are emitted by the Flutter WebView layer.
 class AxeptioEventStreamHandler: NSObject, FlutterStreamHandler {
-    private var eventSink: FlutterEventSink?
-    let axeptioEventListener = AxeptioEventListener()
+  func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink)
+    -> FlutterError?
+  {
+    return nil
+  }
 
-    override init() {
-        super.init()
-
-        axeptioEventListener.onPopupClosedEvent = { [weak self] in
-           guard let self else { return }
-           self.sendEvent(event: "onPopupClosedEvent")
-        }
-
-        axeptioEventListener.onConsentCleared = { [weak self] in
-            guard let self else { return }
-            self.sendEvent(event: "onConsentCleared")
-        }
-
-        axeptioEventListener.onGoogleConsentModeUpdate = { [weak self] consents in
-            guard let self else { return }
-            let encoded = ModelHelper.dictionary(from: consents)
-            self.sendEvent(event: "onGoogleConsentModeUpdate", arguments: ["googleConsentV2": encoded])
-        }
-    }
-
-    func onListen(withArguments arguments: Any?, eventSink events: @escaping FlutterEventSink) -> FlutterError? {
-        eventSink = events
-        return nil
-    }
-
-    func onCancel(withArguments arguments: Any?) -> FlutterError? {
-        eventSink = nil
-        return nil
-    }
-
-    func sendEvent(event: String, arguments: Dictionary<String, Any?>? = nil) {
-        let eventDictionary: NSMutableDictionary = NSMutableDictionary()
-        eventDictionary.setValue(event, forKey: "type")
-        if let arguments = arguments {
-            for (name, value) in arguments {
-                if let value = value {
-                    eventDictionary.setValue(value, forKey: name)
-                }
-            }
-        }
-
-        DispatchQueue.main.async {
-            self.eventSink?(eventDictionary)
-        }
-    }
+  func onCancel(withArguments arguments: Any?) -> FlutterError? {
+    return nil
+  }
 }

--- a/ios/Classes/AxeptioSdkPlugin.swift
+++ b/ios/Classes/AxeptioSdkPlugin.swift
@@ -1,10 +1,8 @@
-import AxeptioSDK
 import Flutter
 import UIKit
 
+/// Stub plugin — consent is handled by the Flutter WebView layer.
 public class AxeptioSdkPlugin: NSObject, FlutterPlugin {
-
-  static var eventStreamHandler: AxeptioEventStreamHandler? = nil
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: "axeptio_sdk", binaryMessenger: registrar.messenger())
@@ -12,9 +10,6 @@ public class AxeptioSdkPlugin: NSObject, FlutterPlugin {
     registrar.addMethodCallDelegate(instance, channel: channel)
 
     let eventStreamHandler = AxeptioEventStreamHandler()
-    AxeptioSdkPlugin.eventStreamHandler = eventStreamHandler
-    Axeptio.shared.setEventListener(eventStreamHandler.axeptioEventListener)
-
     let eventChannel = FlutterEventChannel(
       name: "axeptio_sdk/events", binaryMessenger: registrar.messenger())
     eventChannel.setStreamHandler(eventStreamHandler)
@@ -23,174 +18,9 @@ public class AxeptioSdkPlugin: NSObject, FlutterPlugin {
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
     case "getPlatformVersion":
-      print("getPlatformVersion called")
       result("iOS " + UIDevice.current.systemVersion)
-    case "axeptioToken":
-      result(Axeptio.shared.axeptioToken)
-
-    case "initialize":
-      initialize(call, result: result)
-      result(nil)
-
-    case "setupUI":
-      Axeptio.shared.setupUI()
-      result(nil)
-
-    case "setUserDeniedTracking":
-      guard let args = call.arguments as? [String: Any],
-        let denied = args["denied"] as? Bool
-      else {
-        result(
-          FlutterError.init(
-            code: "invalid_args", message: "setUserDeniedTracking: Missing argument 'denied'",
-            details: nil))
-        return
-      }
-      Axeptio.shared.setUserDeniedTracking(denied: denied)
-      result(nil)
-
-    case "showConsentScreen":
-      Axeptio.shared.showConsentScreen()
-      result(nil)
-
-    case "clearConsent":
-      Axeptio.shared.clearConsent()
-      result(nil)
-
-    case "appendAxeptioTokenURL":
-      guard let arguments = call.arguments as? [String: String],
-        let urlArg = arguments["url"],
-        let url = URL(string: urlArg),
-        let token = arguments["token"]
-      else {
-        result(nil)
-        return
-      }
-
-      let axeptioUrl = Axeptio.shared.appendAxeptioTokenToURL(url, token: token)
-      result(axeptioUrl.absoluteString)
-
-    case "getConsentSavedData":
-      let arguments = call.arguments as? [String: Any]
-      let preferenceKey = arguments?["preferenceKey"] as? String
-
-      let response = Axeptio.shared.getConsentDebugInfo(preferenceKey: preferenceKey)
-
-      let safeResponse = sanitizeForFlutter(response)
-      result(safeResponse)
-
-    case "getConsentDebugInfo":
-      let arguments = call.arguments as? [String: Any]
-      let preferenceKey = arguments?["preferenceKey"] as? String
-
-      let response = Axeptio.shared.getConsentDebugInfo(preferenceKey: preferenceKey)
-
-      let safeResponse = sanitizeForFlutter(response)
-      result(safeResponse)
-
-    case "getVendorConsents":
-      let vendorConsents = Axeptio.shared.getVendorConsents()
-      let safeResponse = sanitizeForFlutter(vendorConsents)
-      result(safeResponse)
-
-    case "getConsentedVendors":
-      let consentedVendors = Axeptio.shared.getConsentedVendors()
-      let safeResponse = sanitizeForFlutter(consentedVendors)
-      result(safeResponse)
-
-    case "getRefusedVendors":
-      let refusedVendors = Axeptio.shared.getRefusedVendors()
-      let safeResponse = sanitizeForFlutter(refusedVendors)
-      result(safeResponse)
-
-    case "isVendorConsented":
-      guard let arguments = call.arguments as? [String: Any],
-        let vendorId = arguments["vendorId"] as? Int
-      else {
-        result(
-          FlutterError.init(
-            code: "invalid_args", message: "isVendorConsented: Missing argument 'vendorId'",
-            details: nil))
-        return
-      }
-      let isConsented = Axeptio.shared.isVendorConsented(vendorId)
-      result(isConsented)
-
-
     default:
       result(FlutterMethodNotImplemented)
     }
-  }
-
-
-  /// Recursively converts values to Flutter-supported types,
-  /// preventing codec crashes.
-  func sanitizeForFlutter(_ value: Any) -> Any? {
-    switch value {
-    case is NSNull, is Bool, is Int, is Double, is String,
-      is FlutterStandardTypedData:
-      return value
-    case let date as Date:
-      // fallback conversion, e.g. ISO string
-      return ISO8601DateFormatter().string(from: date)
-    case let array as [Any]:
-      return array.compactMap { sanitizeForFlutter($0) }
-    case let dict as [String: Any]:
-      return dict.mapValues { sanitizeForFlutter($0) }
-    case let dict as [Int: Bool]:
-      // Convert [Int: Bool] to [String: Bool] for Flutter compatibility
-      return Dictionary(uniqueKeysWithValues: dict.map { (String($0), $1) })
-    default:
-      // unsupported type, stringify as fallback
-      return String(describing: value)
-    }
-  }
-
-  func initialize(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    guard let args = call.arguments as? [String: Any] else {
-      result(
-        FlutterError.init(
-          code: "invalid_args", message: "Wrong arguments for initialize", details: nil))
-      return
-    }
-
-    guard let clientId = args["clientId"] as? String else {
-      result(
-        FlutterError.init(
-          code: "invalid_args", message: "initialize: Missing argument clientId", details: nil))
-      return
-    }
-
-    guard let cookiesVersion = args["cookiesVersion"] as? String else {
-      result(
-        FlutterError.init(
-          code: "invalid_args", message: "initialize: Missing argument cookiesVersion", details: nil
-        ))
-      return
-    }
-
-    guard let targetService = args["targetService"] as? String else {
-      result(
-        FlutterError.init(
-          code: "invalid_args", message: "initialize: Missing argument targetService", details: nil)
-      )
-      return
-    }
-
-    let axeptioService =
-      targetService == "brands" ? AxeptioService.brands : AxeptioService.publisherTcf
-
-    _ = args["token"] as? String
-
-    if let token = args["token"] as? String {
-      Axeptio.shared.initialize(
-        targetService: axeptioService, clientId: clientId, cookiesVersion: cookiesVersion,
-        token: token)
-    } else {
-      Axeptio.shared.initialize(
-        targetService: axeptioService, clientId: clientId, cookiesVersion: cookiesVersion)
-    }
-
-    result(nil)
   }
 }

--- a/ios/Classes/ModelHelper.swift
+++ b/ios/Classes/ModelHelper.swift
@@ -1,14 +1,4 @@
 import Foundation
 
-import AxeptioSDK
-
-class ModelHelper {
-    static func dictionary(from consents: GoogleConsentV2) -> [String: Bool] {
-        return [
-            "analyticsStorage": consents.analyticsStorage == .granted,
-            "adStorage": consents.adStorage == .granted,
-            "adUserData": consents.adUserData == .granted,
-            "adPersonalization": consents.adPersonalization == .granted
-        ]
-    }
-}
+/// Stub — no longer used after native SDK removal.
+class ModelHelper {}

--- a/ios/axeptio_sdk.podspec
+++ b/ios/axeptio_sdk.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/axeptio/flutter-sdk.git" }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency "AxeptioIOSSDK", "2.0.15"
+  s.dependency "AxeptioIOSSDK", "2.0.17"
   s.platform = :ios, '15.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/axeptio_sdk.podspec
+++ b/ios/axeptio_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'axeptio_sdk'
-  s.version          = '2.0.15'
+  s.version          = '2.0.17'
   s.summary          = 'AxeptioSDK for presenting cookies consent to the user'
   s.homepage         = 'https://github.com/axeptio/flutter-sdk'
   s.license          = { :type => 'MIT', :file => '../LICENSE' }

--- a/ios/axeptio_sdk.podspec
+++ b/ios/axeptio_sdk.podspec
@@ -4,7 +4,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'axeptio_sdk'
-  s.version          = '2.0.17'
+  s.version          = '3.0.0'
   s.summary          = 'AxeptioSDK for presenting cookies consent to the user'
   s.homepage         = 'https://github.com/axeptio/flutter-sdk'
   s.license          = { :type => 'MIT', :file => '../LICENSE' }
@@ -12,7 +12,6 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/axeptio/flutter-sdk.git" }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency "AxeptioIOSSDK", "2.0.17"
   s.platform = :ios, '15.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/lib/src/channel/axeptio.dart
+++ b/lib/src/channel/axeptio.dart
@@ -1,10 +1,24 @@
 import 'package:axeptio_sdk/src/events/event_listener.dart';
-import 'package:axeptio_sdk/src/model/model.dart';
 import 'package:axeptio_sdk/src/gvl/gvl_service.dart';
+import 'package:axeptio_sdk/src/model/model.dart';
+import 'package:axeptio_sdk/src/webview/webview_axeptio_sdk.dart';
+import 'package:flutter/material.dart';
 
 import 'axeptio_sdk_platform_interface.dart';
 
 class AxeptioSdk {
+  /// Navigator key required for [showConsentScreen] and [setupUI] to work.
+  ///
+  /// Set this before calling [initialize]:
+  /// ```dart
+  /// AxeptioSdk.navigatorKey = GlobalKey<NavigatorState>();
+  /// // Then pass it to your MaterialApp:
+  /// MaterialApp(navigatorKey: AxeptioSdk.navigatorKey, ...)
+  /// ```
+  static GlobalKey<NavigatorState>? get navigatorKey =>
+      WebViewAxeptioSdk.navigatorKey;
+  static set navigatorKey(GlobalKey<NavigatorState>? key) =>
+      WebViewAxeptioSdk.navigatorKey = key;
   AxeptioService? _targetService;
 
   AxeptioService? get targetService => _targetService;

--- a/lib/src/channel/axeptio_sdk_method_channel.dart
+++ b/lib/src/channel/axeptio_sdk_method_channel.dart
@@ -10,7 +10,8 @@ class MethodChannelAxeptioSdk implements AxeptioSdkPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting
   final methodChannel = const MethodChannel('axeptio_sdk');
-  final EventsHandler _eventsHandler = EventsHandler();
+  final EventsHandler _eventsHandler = EventsHandler(
+      const EventChannel('axeptio_sdk/events').receiveBroadcastStream());
 
   @override
   Future<String?> getPlatformVersion() async {

--- a/lib/src/channel/axeptio_sdk_method_channel.dart
+++ b/lib/src/channel/axeptio_sdk_method_channel.dart
@@ -6,6 +6,14 @@ import 'package:flutter/services.dart';
 import 'axeptio_sdk_platform_interface.dart';
 
 /// An implementation of [AxeptioSdkPlatform] that uses method channels.
+///
+/// Deprecated: native SDK support was removed in v3. The native plugins are
+/// now stubs and most methods will throw [MissingPluginException] at runtime.
+/// Use [WebViewAxeptioSdk] (the default) instead.
+@Deprecated(
+  'Native SDK support was removed in v3; method channel calls will throw. '
+  'Use WebViewAxeptioSdk (the default implementation) instead.',
+)
 class MethodChannelAxeptioSdk implements AxeptioSdkPlatform {
   /// The method channel used to interact with the native platform.
   @visibleForTesting

--- a/lib/src/channel/axeptio_sdk_platform_interface.dart
+++ b/lib/src/channel/axeptio_sdk_platform_interface.dart
@@ -1,16 +1,15 @@
 import 'package:axeptio_sdk/src/events/events.dart';
 import 'package:axeptio_sdk/src/model/model.dart';
+import 'package:axeptio_sdk/src/webview/webview_axeptio_sdk.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
-import 'axeptio_sdk_method_channel.dart';
-
-abstract interface class AxeptioSdkPlatform extends PlatformInterface {
+abstract class AxeptioSdkPlatform extends PlatformInterface {
   /// Constructs a AxeptioSdkPlatform.
   AxeptioSdkPlatform() : super(token: _token);
 
   static final Object _token = Object();
 
-  static AxeptioSdkPlatform _instance = MethodChannelAxeptioSdk();
+  static AxeptioSdkPlatform _instance = WebViewAxeptioSdk();
 
   /// The default instance of [AxeptioSdkPlatform] to use.
   ///

--- a/lib/src/channel/axeptio_sdk_platform_interface.dart
+++ b/lib/src/channel/axeptio_sdk_platform_interface.dart
@@ -13,7 +13,7 @@ abstract class AxeptioSdkPlatform extends PlatformInterface {
 
   /// The default instance of [AxeptioSdkPlatform] to use.
   ///
-  /// Defaults to [MethodChannelAxeptioSdk].
+  /// Defaults to [WebViewAxeptioSdk].
   static AxeptioSdkPlatform get instance => _instance;
 
   /// Platform-specific implementations should set this with their own

--- a/lib/src/events/events_handler.dart
+++ b/lib/src/events/events_handler.dart
@@ -8,6 +8,11 @@ import 'event_listener.dart';
 class EventsHandler {
   List<AxeptioEventListener> listeners = [];
 
+  /// Creates an [EventsHandler].
+  ///
+  /// If [stream] is provided, events are received from it automatically.
+  /// When omitted (WebView implementation), events are dispatched directly
+  /// via [handleAxeptioEvent] — no platform channel subscription is made.
   EventsHandler([Stream<dynamic>? stream]) {
     stream?.listen(handleAxeptioEvent, onError: handleDAxeptioErrorEvent);
   }

--- a/lib/src/events/events_handler.dart
+++ b/lib/src/events/events_handler.dart
@@ -8,8 +8,8 @@ import 'event_listener.dart';
 class EventsHandler {
   List<AxeptioEventListener> listeners = [];
 
-  EventsHandler(Stream<dynamic> stream) {
-    stream.listen(handleAxeptioEvent, onError: handleDAxeptioErrorEvent);
+  EventsHandler([Stream<dynamic>? stream]) {
+    stream?.listen(handleAxeptioEvent, onError: handleDAxeptioErrorEvent);
   }
 
   handleAxeptioEvent(dynamic event) {

--- a/lib/src/events/events_handler.dart
+++ b/lib/src/events/events_handler.dart
@@ -12,7 +12,7 @@ class EventsHandler {
   ///
   /// If [stream] is provided, events are received from it automatically.
   /// When omitted (WebView implementation), events are dispatched directly
-  /// via [handleAxeptioEvent] — no platform channel subscription is made.
+  /// via listener callbacks by the caller — no platform channel subscription is made.
   EventsHandler([Stream<dynamic>? stream]) {
     stream?.listen(handleAxeptioEvent, onError: handleDAxeptioErrorEvent);
   }
@@ -22,13 +22,13 @@ class EventsHandler {
 
     switch (eventType) {
       case 'onPopupClosedEvent':
-        for (var listener in listeners) {
+        for (final listener in List.of(listeners)) {
           listener.onPopupClosedEvent();
         }
         break;
 
       case 'onConsentCleared':
-        for (var listener in listeners) {
+        for (final listener in List.of(listeners)) {
           listener.onConsentCleared();
         }
         break;
@@ -36,7 +36,7 @@ class EventsHandler {
       case 'onGoogleConsentModeUpdate':
         final ConsentsV2 consents =
             ConsentsV2.fromDictionary(event["googleConsentV2"]);
-        for (var listener in listeners) {
+        for (final listener in List.of(listeners)) {
           listener.onGoogleConsentModeUpdate(consents);
         }
         break;

--- a/lib/src/events/events_handler.dart
+++ b/lib/src/events/events_handler.dart
@@ -2,18 +2,14 @@
 
 import 'package:axeptio_sdk/src/model/consents_v2.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/services.dart';
 
 import 'event_listener.dart';
 
 class EventsHandler {
-  static const EventChannel _eventChannel = EventChannel('axeptio_sdk/events');
   List<AxeptioEventListener> listeners = [];
 
-  EventsHandler() {
-    _eventChannel
-        .receiveBroadcastStream()
-        .listen(handleAxeptioEvent, onError: handleDAxeptioErrorEvent);
+  EventsHandler(Stream<dynamic> stream) {
+    stream.listen(handleAxeptioEvent, onError: handleDAxeptioErrorEvent);
   }
 
   handleAxeptioEvent(dynamic event) {

--- a/lib/src/gvl/gvl_service.dart
+++ b/lib/src/gvl/gvl_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'dart:developer' as developer;
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../model/vendor_info.dart';
@@ -18,6 +19,9 @@ class GVLService {
   static GVLService get instance => _instance ??= GVLService._();
 
   GVLService._();
+
+  @visibleForTesting
+  static void resetInstance() => _instance = null;
 
   Map<int, VendorInfo>? _cachedVendors;
   String? _cachedVersion;

--- a/lib/src/src.dart
+++ b/lib/src/src.dart
@@ -9,3 +9,7 @@ export 'model/axeptio_service.dart';
 export 'model/consents_v2.dart';
 export 'model/model.dart';
 export 'preferences/native_default_preferences.dart';
+export 'webview/axeptio_consent_view.dart';
+export 'webview/consent_url_builder.dart';
+export 'webview/tcf_storage.dart';
+export 'webview/webview_axeptio_sdk.dart';

--- a/lib/src/src.dart
+++ b/lib/src/src.dart
@@ -9,7 +9,3 @@ export 'model/axeptio_service.dart';
 export 'model/consents_v2.dart';
 export 'model/model.dart';
 export 'preferences/native_default_preferences.dart';
-export 'webview/axeptio_consent_view.dart';
-export 'webview/consent_url_builder.dart';
-export 'webview/tcf_storage.dart';
-export 'webview/webview_axeptio_sdk.dart';

--- a/lib/src/webview/axeptio_consent_view.dart
+++ b/lib/src/webview/axeptio_consent_view.dart
@@ -51,8 +51,8 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
       ..setNavigationDelegate(NavigationDelegate(
         onPageFinished: (_) => _onPageFinished(),
         onNavigationRequest: (request) {
-          final host = Uri.tryParse(request.url)?.host ?? '';
-          if (host == 'static.axept.io') {
+          final uri = Uri.tryParse(request.url);
+          if (uri?.scheme == 'https' && uri?.host == 'static.axept.io') {
             return NavigationDecision.navigate;
           }
           return NavigationDecision.prevent;

--- a/lib/src/webview/axeptio_consent_view.dart
+++ b/lib/src/webview/axeptio_consent_view.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
 
@@ -16,6 +15,7 @@ class AxeptioConsentView extends StatefulWidget {
   final Uri consentUrl;
   final bool attDenied;
   final String? storedTcString;
+  final bool showConsentManager;
   final void Function(String name, Map<String, dynamic>? payload) onJsEvent;
   final void Function() onClose;
 
@@ -26,6 +26,7 @@ class AxeptioConsentView extends StatefulWidget {
     required this.onClose,
     this.attDenied = false,
     this.storedTcString,
+    this.showConsentManager = false,
   });
 
   @override
@@ -65,7 +66,8 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
       if (widget.storedTcString != null) '_ax_tcstring': widget.storedTcString!,
     };
     final script = items.entries
-        .map((e) => "localStorage.setItem('${e.key}', '${e.value}');")
+        .map((e) =>
+            "localStorage.setItem(${jsonEncode(e.key)}, ${jsonEncode(e.value)});")
         .join('\n');
     await _controller.runJavaScript(script);
   }
@@ -107,6 +109,11 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
     final subscription = payload['subscription'];
     if (subscription == false) {
       widget.onClose();
+      return;
+    }
+    if (widget.showConsentManager) {
+      _controller
+          .runJavaScript("window.axeptioSDK?.requestShow?.('consentManager')");
       return;
     }
     final showCmp = payload['showCmp'] as bool? ?? false;

--- a/lib/src/webview/axeptio_consent_view.dart
+++ b/lib/src/webview/axeptio_consent_view.dart
@@ -1,0 +1,133 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+const String _polyfillScript = r'''
+window.webkit = window.webkit || {};
+window.webkit.messageHandlers = window.webkit.messageHandlers || {};
+window.webkit.messageHandlers.axeptioSdk = {
+  postMessage: function(data) { axeptioSdk.postMessage(JSON.stringify(data)); }
+};
+''';
+
+class AxeptioConsentView extends StatefulWidget {
+  final Uri consentUrl;
+  final bool attDenied;
+  final String? storedTcString;
+  final void Function(String name, Map<String, dynamic>? payload) onJsEvent;
+  final void Function() onClose;
+
+  const AxeptioConsentView({
+    super.key,
+    required this.consentUrl,
+    required this.onJsEvent,
+    required this.onClose,
+    this.attDenied = false,
+    this.storedTcString,
+  });
+
+  @override
+  State<AxeptioConsentView> createState() => AxeptioConsentViewState();
+}
+
+/// Public state class to allow testing of message handling logic.
+@visibleForTesting
+class AxeptioConsentViewState extends State<AxeptioConsentView> {
+  late final WebViewController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..addJavaScriptChannel(
+        'axeptioSdk',
+        onMessageReceived: _onMessage,
+      )
+      ..setNavigationDelegate(NavigationDelegate(
+        onPageFinished: (_) => _onPageFinished(),
+      ))
+      ..loadRequest(widget.consentUrl);
+  }
+
+  Future<void> _onPageFinished() async {
+    await _injectLocalStorage();
+    await _injectPolyfill();
+  }
+
+  Future<void> _injectLocalStorage() async {
+    final items = <String, String>{
+      '_ax_app_sdk_mode': 'true',
+      '_ax_user_cookies_duration': '190',
+      if (widget.attDenied) '_ax_app_att_denied': 'true',
+      if (widget.storedTcString != null) '_ax_tcstring': widget.storedTcString!,
+    };
+    final script = items.entries
+        .map((e) => "localStorage.setItem('${e.key}', '${e.value}');")
+        .join('\n');
+    await _controller.runJavaScript(script);
+  }
+
+  Future<void> _injectPolyfill() async {
+    await _controller.runJavaScript(_polyfillScript);
+  }
+
+  void _onMessage(JavaScriptMessage message) {
+    try {
+      final decoded = jsonDecode(message.message) as Map<String, dynamic>;
+      final name = decoded['name'] as String?;
+      if (name == null) return;
+
+      final payloadRaw = decoded['payload'];
+      Map<String, dynamic>? payload;
+      if (payloadRaw is String && payloadRaw.isNotEmpty) {
+        payload = jsonDecode(payloadRaw) as Map<String, dynamic>?;
+      } else if (payloadRaw is Map) {
+        payload = Map<String, dynamic>.from(payloadRaw);
+      }
+
+      if (name == 'app:cookies:ready') {
+        _handleCookiesReady(payload);
+      } else if (name == 'cookies:close') {
+        widget.onJsEvent(name, payload);
+        widget.onClose();
+      } else {
+        widget.onJsEvent(name, payload);
+      }
+    } catch (_) {}
+  }
+
+  void _handleCookiesReady(Map<String, dynamic>? payload) {
+    if (payload == null) {
+      widget.onClose();
+      return;
+    }
+    final subscription = payload['subscription'];
+    if (subscription == false) {
+      widget.onClose();
+      return;
+    }
+    final showCmp = payload['showCmp'] as bool? ?? false;
+    if (!showCmp) {
+      widget.onClose();
+    }
+  }
+
+  @visibleForTesting
+  Future<void> simulatePageFinished() => _onPageFinished();
+
+  @visibleForTesting
+  void simulateJsMessage(String rawJson) =>
+      _onMessage(JavaScriptMessage(message: rawJson));
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: WebViewWidget(controller: _controller),
+      ),
+    );
+  }
+}

--- a/lib/src/webview/axeptio_consent_view.dart
+++ b/lib/src/webview/axeptio_consent_view.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
@@ -49,6 +50,13 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
       )
       ..setNavigationDelegate(NavigationDelegate(
         onPageFinished: (_) => _onPageFinished(),
+        onNavigationRequest: (request) {
+          final host = Uri.tryParse(request.url)?.host ?? '';
+          if (host == 'static.axept.io') {
+            return NavigationDecision.navigate;
+          }
+          return NavigationDecision.prevent;
+        },
       ))
       ..loadRequest(widget.consentUrl);
   }
@@ -91,7 +99,7 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
       }
 
       if (name == 'app:cookies:ready') {
-        _handleCookiesReady(payload);
+        unawaited(_handleCookiesReady(payload));
       } else if (name == 'cookies:close') {
         widget.onJsEvent(name, payload);
         widget.onClose();
@@ -101,7 +109,7 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
     } catch (_) {}
   }
 
-  void _handleCookiesReady(Map<String, dynamic>? payload) {
+  Future<void> _handleCookiesReady(Map<String, dynamic>? payload) async {
     if (payload == null) {
       widget.onClose();
       return;
@@ -112,7 +120,7 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
       return;
     }
     if (widget.showConsentManager) {
-      _controller
+      await _controller
           .runJavaScript("window.axeptioSDK?.requestShow?.('consentManager')");
       return;
     }

--- a/lib/src/webview/axeptio_consent_view.dart
+++ b/lib/src/webview/axeptio_consent_view.dart
@@ -1,8 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:webview_flutter/webview_flutter.dart';
+
+/// Duration in days for the Axeptio user cookie consent window.
+const int _axUserCookiesDurationDays = 190;
 
 const String _polyfillScript = r'''
 window.webkit = window.webkit || {};
@@ -69,7 +73,7 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
   Future<void> _injectLocalStorage() async {
     final items = <String, String>{
       '_ax_app_sdk_mode': 'true',
-      '_ax_user_cookies_duration': '190',
+      '_ax_user_cookies_duration': _axUserCookiesDurationDays.toString(),
       if (widget.attDenied) '_ax_app_att_denied': 'true',
       if (widget.storedTcString != null) '_ax_tcstring': widget.storedTcString!,
     };
@@ -106,7 +110,11 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
       } else {
         widget.onJsEvent(name, payload);
       }
-    } catch (_) {}
+    } catch (e) {
+      if (kDebugMode) {
+        print('AxeptioConsentView: failed to parse JS message: $e');
+      }
+    }
   }
 
   Future<void> _handleCookiesReady(Map<String, dynamic>? payload) async {

--- a/lib/src/webview/consent_url_builder.dart
+++ b/lib/src/webview/consent_url_builder.dart
@@ -30,7 +30,11 @@ class ConsentUrlBuilder {
     final params = Map<String, String>.from(uri.queryParameters);
     params['clientId'] = clientId;
     params['cookiesVersion'] = cookiesVersion;
-    if (token != null) params['axeptio_token'] = token;
+    if (token != null) {
+      params['axeptio_token'] = token;
+    } else {
+      params.remove('axeptio_token');
+    }
     return uri.replace(queryParameters: params);
   }
 }

--- a/lib/src/webview/consent_url_builder.dart
+++ b/lib/src/webview/consent_url_builder.dart
@@ -24,9 +24,10 @@ class ConsentUrlBuilder {
     return Uri.parse(base).replace(queryParameters: params);
   }
 
-  static Uri appendToken(
+  static Uri? appendToken(
       String url, String clientId, String cookiesVersion, String? token) {
-    final uri = Uri.parse(url);
+    final uri = Uri.tryParse(url);
+    if (uri == null) return null; // coverage:ignore-line
     final params = Map<String, String>.from(uri.queryParameters);
     params['clientId'] = clientId;
     params['cookiesVersion'] = cookiesVersion;

--- a/lib/src/webview/consent_url_builder.dart
+++ b/lib/src/webview/consent_url_builder.dart
@@ -1,0 +1,36 @@
+import 'package:axeptio_sdk/src/model/axeptio_service.dart';
+
+class ConsentUrlBuilder {
+  static const String _publishersUrl =
+      'https://static.axept.io/app-sdk-webview.html';
+  static const String _brandsUrl =
+      'https://static.axept.io/app-sdk-webview-for-brands.html';
+
+  static Uri build({
+    required AxeptioService service,
+    required String clientId,
+    required String cookiesVersion,
+    String? token,
+    bool showConsentManager = false,
+  }) {
+    final base =
+        service == AxeptioService.publishers ? _publishersUrl : _brandsUrl;
+    final params = <String, String>{
+      'clientId': clientId,
+      'cookiesVersion': cookiesVersion,
+    };
+    if (token != null) params['axeptio_token'] = token;
+    if (showConsentManager) params['showConsentManager'] = 'true';
+    return Uri.parse(base).replace(queryParameters: params);
+  }
+
+  static Uri appendToken(
+      String url, String clientId, String cookiesVersion, String? token) {
+    final uri = Uri.parse(url);
+    final params = Map<String, String>.from(uri.queryParameters);
+    params['clientId'] = clientId;
+    params['cookiesVersion'] = cookiesVersion;
+    if (token != null) params['axeptio_token'] = token;
+    return uri.replace(queryParameters: params);
+  }
+}

--- a/lib/src/webview/tcf_storage.dart
+++ b/lib/src/webview/tcf_storage.dart
@@ -28,6 +28,7 @@ class TcfStorage {
     if (payload['axeptio_token'] != null) {
       await _prefs.setString(
           'AX_CLIENT_TOKEN', payload['axeptio_token'].toString());
+      await _prefs.remove('_ax_token');
     }
     if (payload['axeptio_cookies'] != null) {
       await _prefs.setString(
@@ -60,9 +61,7 @@ class TcfStorage {
 
   Future<void> clearAll() async {
     final keys = [
-      ...NativeDefaultPreferences.brandKeys,
-      ...NativeDefaultPreferences.tcfKeys,
-      'AX_CLIENT_TOKEN',
+      ...NativeDefaultPreferences.allKeys,
       '_ax_token',
       'widget_scope',
       'vendor_consent_summary',
@@ -75,9 +74,7 @@ class TcfStorage {
   Map<String, dynamic> getAllData() {
     final result = <String, dynamic>{};
     final keys = [
-      ...NativeDefaultPreferences.brandKeys,
-      ...NativeDefaultPreferences.tcfKeys,
-      'AX_CLIENT_TOKEN',
+      ...NativeDefaultPreferences.allKeys,
       '_ax_token',
       'widget_scope',
     ];

--- a/lib/src/webview/tcf_storage.dart
+++ b/lib/src/webview/tcf_storage.dart
@@ -78,6 +78,7 @@ class TcfStorage {
       ...NativeDefaultPreferences.brandKeys,
       ...NativeDefaultPreferences.tcfKeys,
       'AX_CLIENT_TOKEN',
+      '_ax_token',
       'widget_scope',
     ];
     for (final key in keys) {

--- a/lib/src/webview/tcf_storage.dart
+++ b/lib/src/webview/tcf_storage.dart
@@ -1,0 +1,108 @@
+import 'package:axeptio_sdk/src/preferences/native_default_preferences.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class TcfStorage {
+  final SharedPreferences _prefs;
+
+  TcfStorage(this._prefs);
+
+  static Future<TcfStorage> create() async {
+    final prefs = await SharedPreferences.getInstance();
+    return TcfStorage(prefs);
+  }
+
+  String? get tcString => _prefs.getString('IABTCF_TCString');
+
+  String? get axeptioToken => _prefs.getString('_ax_token');
+
+  Future<void> writeIabTcfFields(Map<String, dynamic>? fields) async {
+    if (fields == null) return;
+    for (final entry in fields.entries) {
+      await _writeValue(entry.key, entry.value);
+    }
+  }
+
+  Future<void> writeConsentSaved(Map<String, dynamic>? payload) async {
+    if (payload == null) return;
+    if (payload['axeptio_token'] != null) {
+      await _prefs.setString('_ax_token', payload['axeptio_token'].toString());
+    }
+    if (payload['axeptio_cookies'] != null) {
+      await _prefs.setString(
+          'axeptio_cookies', payload['axeptio_cookies'].toString());
+    }
+    if (payload['axeptio_all_vendors'] != null) {
+      await _prefs.setString(
+          'axeptio_all_vendors', payload['axeptio_all_vendors'].toString());
+    }
+    if (payload['axeptio_authorized_vendors'] != null) {
+      await _prefs.setString('axeptio_authorized_vendors',
+          payload['axeptio_authorized_vendors'].toString());
+    }
+  }
+
+  Future<void> writeCookies(Map<String, dynamic>? payload) async {
+    if (payload == null) return;
+    for (final entry in payload.entries) {
+      await _writeValue(entry.key, entry.value);
+    }
+  }
+
+  Future<void> writeScope(Map<String, dynamic>? payload) async {
+    if (payload == null) return;
+    final scope = payload['scope'];
+    if (scope != null) {
+      await _prefs.setString('widget_scope', scope.toString());
+    }
+  }
+
+  Future<void> clearAll() async {
+    final keys = [
+      ...NativeDefaultPreferences.brandKeys,
+      ...NativeDefaultPreferences.tcfKeys,
+      '_ax_token',
+      'widget_scope',
+      'vendor_consent_summary',
+    ];
+    for (final key in keys) {
+      await _prefs.remove(key);
+    }
+  }
+
+  Map<String, dynamic> getAllData() {
+    final result = <String, dynamic>{};
+    final keys = [
+      ...NativeDefaultPreferences.brandKeys,
+      ...NativeDefaultPreferences.tcfKeys,
+      '_ax_token',
+      'widget_scope',
+    ];
+    for (final key in keys) {
+      final value = _prefs.get(key);
+      if (value != null) result[key] = value;
+    }
+    return result;
+  }
+
+  Map<int, bool> getVendorConsents() {
+    final bitString = _prefs.getString('IABTCF_VendorConsents') ?? '';
+    final result = <int, bool>{};
+    for (int i = 0; i < bitString.length; i++) {
+      result[i + 1] = bitString[i] == '1';
+    }
+    return result;
+  }
+
+  Future<void> _writeValue(String key, dynamic value) async {
+    if (value == null) return;
+    if (value is bool) {
+      await _prefs.setBool(key, value);
+    } else if (value is int) {
+      await _prefs.setInt(key, value);
+    } else if (value is double) {
+      await _prefs.setDouble(key, value);
+    } else {
+      await _prefs.setString(key, value.toString());
+    }
+  }
+}

--- a/lib/src/webview/tcf_storage.dart
+++ b/lib/src/webview/tcf_storage.dart
@@ -13,7 +13,8 @@ class TcfStorage {
 
   String? get tcString => _prefs.getString('IABTCF_TCString');
 
-  String? get axeptioToken => _prefs.getString('_ax_token');
+  String? get axeptioToken =>
+      _prefs.getString('AX_CLIENT_TOKEN') ?? _prefs.getString('_ax_token');
 
   Future<void> writeIabTcfFields(Map<String, dynamic>? fields) async {
     if (fields == null) return;
@@ -25,7 +26,8 @@ class TcfStorage {
   Future<void> writeConsentSaved(Map<String, dynamic>? payload) async {
     if (payload == null) return;
     if (payload['axeptio_token'] != null) {
-      await _prefs.setString('_ax_token', payload['axeptio_token'].toString());
+      await _prefs.setString(
+          'AX_CLIENT_TOKEN', payload['axeptio_token'].toString());
     }
     if (payload['axeptio_cookies'] != null) {
       await _prefs.setString(
@@ -60,6 +62,7 @@ class TcfStorage {
     final keys = [
       ...NativeDefaultPreferences.brandKeys,
       ...NativeDefaultPreferences.tcfKeys,
+      'AX_CLIENT_TOKEN',
       '_ax_token',
       'widget_scope',
       'vendor_consent_summary',
@@ -74,7 +77,7 @@ class TcfStorage {
     final keys = [
       ...NativeDefaultPreferences.brandKeys,
       ...NativeDefaultPreferences.tcfKeys,
-      '_ax_token',
+      'AX_CLIENT_TOKEN',
       'widget_scope',
     ];
     for (final key in keys) {

--- a/lib/src/webview/webview_axeptio_sdk.dart
+++ b/lib/src/webview/webview_axeptio_sdk.dart
@@ -1,0 +1,200 @@
+import 'dart:async';
+
+import 'package:axeptio_sdk/src/channel/axeptio_sdk_platform_interface.dart';
+import 'package:axeptio_sdk/src/events/event_listener.dart';
+import 'package:axeptio_sdk/src/events/events_handler.dart';
+import 'package:axeptio_sdk/src/model/consents_v2.dart';
+import 'package:axeptio_sdk/src/model/model.dart';
+import 'package:axeptio_sdk/src/webview/axeptio_consent_view.dart';
+import 'package:axeptio_sdk/src/webview/consent_url_builder.dart';
+import 'package:axeptio_sdk/src/webview/tcf_storage.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class WebViewAxeptioSdk implements AxeptioSdkPlatform {
+  static GlobalKey<NavigatorState>? navigatorKey;
+
+  String? _clientId;
+  String? _cookiesVersion;
+  AxeptioService? _targetService;
+  String? _token;
+  bool _attDenied = false;
+  TcfStorage? _storage;
+
+  final StreamController<dynamic> _eventController =
+      StreamController<dynamic>.broadcast();
+  late final EventsHandler _eventsHandler;
+
+  WebViewAxeptioSdk() {
+    _eventsHandler = EventsHandler(_eventController.stream);
+  }
+
+  @override
+  Future<String?> getPlatformVersion() async => null;
+
+  @override
+  Future<String?> get axeptioToken async => _storage?.axeptioToken;
+
+  @override
+  Future<void> initialize(AxeptioService targetService, String clientId,
+      String cookiesVersion, String? token) async {
+    _targetService = targetService;
+    _clientId = clientId;
+    _cookiesVersion = cookiesVersion;
+    _token = token;
+    _storage = await TcfStorage.create();
+  }
+
+  @override
+  Future<void> setupUI() async {
+    final storage = _storage;
+    if (storage == null) return;
+    if (storage.tcString == null || storage.tcString!.isEmpty) {
+      await showConsentScreen();
+    }
+  }
+
+  @override
+  Future<void> setUserDeniedTracking() async {
+    _attDenied = true;
+  }
+
+  @override
+  Future<void> showConsentScreen() async {
+    final key = navigatorKey;
+    if (key == null || key.currentState == null) return;
+
+    final clientId = _clientId;
+    final cookiesVersion = _cookiesVersion;
+    final service = _targetService;
+    if (clientId == null || cookiesVersion == null || service == null) return;
+
+    final url = ConsentUrlBuilder.build(
+      service: service,
+      clientId: clientId,
+      cookiesVersion: cookiesVersion,
+      token: _token,
+    );
+
+    key.currentState!.push(
+      MaterialPageRoute(
+        builder: (_) => AxeptioConsentView(
+          consentUrl: url,
+          attDenied: _attDenied,
+          storedTcString: _storage?.tcString,
+          onJsEvent: handleJsEvent,
+          onClose: () => key.currentState?.pop(),
+        ),
+        fullscreenDialog: true,
+      ),
+    );
+  }
+
+  @override
+  Future<void> clearConsent() async {
+    await _storage?.clearAll();
+    for (final listener in _eventsHandler.listeners) {
+      listener.onConsentCleared();
+    }
+  }
+
+  @override
+  Future<Map<String, dynamic>?> getConsentSavedData(
+      {String? preferenceKey}) async {
+    final storage = _storage;
+    if (storage == null) return null;
+    final all = storage.getAllData();
+    if (preferenceKey != null) {
+      final value = all[preferenceKey];
+      return value != null ? {preferenceKey: value} : null;
+    }
+    return all.isNotEmpty ? all : null;
+  }
+
+  @override
+  Future<Map<String, dynamic>?> getConsentDebugInfo(
+      {String? preferenceKey}) async {
+    return getConsentSavedData(preferenceKey: preferenceKey);
+  }
+
+  @override
+  Future<Map<int, bool>> getVendorConsents() async {
+    return _storage?.getVendorConsents() ?? {};
+  }
+
+  @override
+  Future<List<int>> getConsentedVendors() async {
+    final consents = await getVendorConsents();
+    return consents.entries.where((e) => e.value).map((e) => e.key).toList();
+  }
+
+  @override
+  Future<List<int>> getRefusedVendors() async {
+    final consents = await getVendorConsents();
+    return consents.entries.where((e) => !e.value).map((e) => e.key).toList();
+  }
+
+  @override
+  Future<bool> isVendorConsented(int vendorId) async {
+    final consents = await getVendorConsents();
+    return consents[vendorId] ?? false;
+  }
+
+  @override
+  addEventListener(AxeptioEventListener listener) {
+    _eventsHandler.addEventListener(listener);
+  }
+
+  @override
+  removeEventListener(AxeptioEventListener listener) {
+    _eventsHandler.removeEventListener(listener);
+  }
+
+  @override
+  Future<String?> appendAxeptioTokenURL(String url, String token) async {
+    final clientId = _clientId;
+    final cookiesVersion = _cookiesVersion;
+    if (clientId == null || cookiesVersion == null) return url;
+    return ConsentUrlBuilder.appendToken(url, clientId, cookiesVersion, token)
+        .toString();
+  }
+
+  @visibleForTesting
+  void handleJsEvent(String name, Map<String, dynamic>? payload) {
+    switch (name) {
+      case 'iabtcf':
+        _storage?.writeIabTcfFields(payload);
+        break;
+      case 'consent:saved':
+        _storage?.writeConsentSaved(payload);
+        break;
+      case 'axeptio:cookies':
+        _storage?.writeCookies(payload);
+        break;
+      case 'cookies:complete':
+        _storage?.writeScope(payload);
+        break;
+      case 'cookies:close':
+        for (final listener in _eventsHandler.listeners) {
+          listener.onPopupClosedEvent();
+        }
+        break;
+      case 'google:consent-mode-v2-update':
+        handleGoogleConsentMode(payload);
+        break;
+    }
+  }
+
+  void handleGoogleConsentMode(Map<String, dynamic>? payload) {
+    if (payload == null) return;
+    final consents = ConsentsV2(
+      payload['analytics_storage'] == true,
+      payload['ad_storage'] == true,
+      payload['ad_user_data'] == true,
+      payload['ad_personalization'] == true,
+    );
+    for (final listener in _eventsHandler.listeners) {
+      listener.onGoogleConsentModeUpdate(consents);
+    }
+  }
+}

--- a/lib/src/webview/webview_axeptio_sdk.dart
+++ b/lib/src/webview/webview_axeptio_sdk.dart
@@ -153,7 +153,8 @@ class WebViewAxeptioSdk extends AxeptioSdkPlatform {
     final cookiesVersion = _cookiesVersion;
     if (clientId == null || cookiesVersion == null) return url;
     return ConsentUrlBuilder.appendToken(url, clientId, cookiesVersion, token)
-        .toString();
+            ?.toString() ??
+        url;
   }
 
   @visibleForTesting

--- a/lib/src/webview/webview_axeptio_sdk.dart
+++ b/lib/src/webview/webview_axeptio_sdk.dart
@@ -1,17 +1,13 @@
-import 'dart:async';
-
 import 'package:axeptio_sdk/src/channel/axeptio_sdk_platform_interface.dart';
 import 'package:axeptio_sdk/src/events/event_listener.dart';
 import 'package:axeptio_sdk/src/events/events_handler.dart';
-import 'package:axeptio_sdk/src/model/consents_v2.dart';
 import 'package:axeptio_sdk/src/model/model.dart';
 import 'package:axeptio_sdk/src/webview/axeptio_consent_view.dart';
 import 'package:axeptio_sdk/src/webview/consent_url_builder.dart';
 import 'package:axeptio_sdk/src/webview/tcf_storage.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-class WebViewAxeptioSdk implements AxeptioSdkPlatform {
+class WebViewAxeptioSdk extends AxeptioSdkPlatform {
   static GlobalKey<NavigatorState>? navigatorKey;
 
   String? _clientId;
@@ -21,12 +17,10 @@ class WebViewAxeptioSdk implements AxeptioSdkPlatform {
   bool _attDenied = false;
   TcfStorage? _storage;
 
-  final StreamController<dynamic> _eventController =
-      StreamController<dynamic>.broadcast();
   late final EventsHandler _eventsHandler;
 
-  WebViewAxeptioSdk() {
-    _eventsHandler = EventsHandler(_eventController.stream);
+  WebViewAxeptioSdk() : super() {
+    _eventsHandler = EventsHandler();
   }
 
   @override
@@ -82,7 +76,8 @@ class WebViewAxeptioSdk implements AxeptioSdkPlatform {
           consentUrl: url,
           attDenied: _attDenied,
           storedTcString: _storage?.tcString,
-          onJsEvent: handleJsEvent,
+          showConsentManager: true,
+          onJsEvent: (name, payload) => handleJsEvent(name, payload),
           onClose: () => key.currentState?.pop(),
         ),
         fullscreenDialog: true,
@@ -160,19 +155,19 @@ class WebViewAxeptioSdk implements AxeptioSdkPlatform {
   }
 
   @visibleForTesting
-  void handleJsEvent(String name, Map<String, dynamic>? payload) {
+  Future<void> handleJsEvent(String name, Map<String, dynamic>? payload) async {
     switch (name) {
       case 'iabtcf':
-        _storage?.writeIabTcfFields(payload);
+        await _storage?.writeIabTcfFields(payload);
         break;
       case 'consent:saved':
-        _storage?.writeConsentSaved(payload);
+        await _storage?.writeConsentSaved(payload);
         break;
       case 'axeptio:cookies':
-        _storage?.writeCookies(payload);
+        await _storage?.writeCookies(payload);
         break;
       case 'cookies:complete':
-        _storage?.writeScope(payload);
+        await _storage?.writeScope(payload);
         break;
       case 'cookies:close':
         for (final listener in _eventsHandler.listeners) {

--- a/lib/src/webview/webview_axeptio_sdk.dart
+++ b/lib/src/webview/webview_axeptio_sdk.dart
@@ -67,7 +67,7 @@ class WebViewAxeptioSdk extends AxeptioSdkPlatform {
       service: service,
       clientId: clientId,
       cookiesVersion: cookiesVersion,
-      token: _token,
+      token: _storage?.axeptioToken ?? _token,
     );
 
     key.currentState!.push(
@@ -88,7 +88,8 @@ class WebViewAxeptioSdk extends AxeptioSdkPlatform {
   @override
   Future<void> clearConsent() async {
     await _storage?.clearAll();
-    for (final listener in _eventsHandler.listeners) {
+    _token = null;
+    for (final listener in List.of(_eventsHandler.listeners)) {
       listener.onConsentCleared();
     }
   }
@@ -170,7 +171,7 @@ class WebViewAxeptioSdk extends AxeptioSdkPlatform {
         await _storage?.writeScope(payload);
         break;
       case 'cookies:close':
-        for (final listener in _eventsHandler.listeners) {
+        for (final listener in List.of(_eventsHandler.listeners)) {
           listener.onPopupClosedEvent();
         }
         break;
@@ -188,7 +189,7 @@ class WebViewAxeptioSdk extends AxeptioSdkPlatform {
       payload['ad_user_data'] == true,
       payload['ad_personalization'] == true,
     );
-    for (final listener in _eventsHandler.listeners) {
+    for (final listener in List.of(_eventsHandler.listeners)) {
       listener.onGoogleConsentModeUpdate(consents);
     }
   }

--- a/lib/src/webview/webview_axeptio_sdk.dart
+++ b/lib/src/webview/webview_axeptio_sdk.dart
@@ -27,7 +27,7 @@ class WebViewAxeptioSdk extends AxeptioSdkPlatform {
   Future<String?> getPlatformVersion() async => null;
 
   @override
-  Future<String?> get axeptioToken async => _storage?.axeptioToken;
+  Future<String?> get axeptioToken async => _storage?.axeptioToken ?? _token;
 
   @override
   Future<void> initialize(AxeptioService targetService, String clientId,
@@ -68,6 +68,7 @@ class WebViewAxeptioSdk extends AxeptioSdkPlatform {
       clientId: clientId,
       cookiesVersion: cookiesVersion,
       token: _storage?.axeptioToken ?? _token,
+      showConsentManager: true,
     );
 
     key.currentState!.push(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^3.0.0
+  webview_flutter_platform_interface: ^2.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: axeptio_sdk
 description: "Axeptio flutter sdk for presenting cookies consent to the user."
 
-version: 2.0.18
+version: 2.0.19
 
 repository: https://github.com/axeptio/flutter-sdk
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   plugin_platform_interface: ^2.0.2
   http: ^1.1.0
   shared_preferences: ^2.2.2
+  webview_flutter: ^4.10.0
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: axeptio_sdk
 description: "Axeptio flutter sdk for presenting cookies consent to the user."
 
-version: 2.0.19
+version: 3.0.0
 
 repository: https://github.com/axeptio/flutter-sdk
 

--- a/test/axeptio_sdk_method_channel_test.dart
+++ b/test/axeptio_sdk_method_channel_test.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: deprecated_member_use_from_same_package
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:axeptio_sdk/src/channel/axeptio_sdk_method_channel.dart';

--- a/test/axeptio_sdk_test.dart
+++ b/test/axeptio_sdk_test.dart
@@ -1,4 +1,5 @@
 import 'package:axeptio_sdk/axeptio_sdk.dart';
+import 'package:axeptio_sdk/src/webview/webview_axeptio_sdk.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/axeptio_sdk_test.dart
+++ b/test/axeptio_sdk_test.dart
@@ -264,8 +264,8 @@ void main() {
   final AxeptioSdkPlatform initialPlatform = AxeptioSdkPlatform.instance;
 
   group('Platform Interface', () {
-    test('$MethodChannelAxeptioSdk is the default instance', () {
-      expect(initialPlatform, isInstanceOf<MethodChannelAxeptioSdk>());
+    test('WebViewAxeptioSdk is the default instance', () {
+      expect(initialPlatform, isInstanceOf<WebViewAxeptioSdk>());
     });
 
     test('getPlatformVersion', () async {

--- a/test/channel/axeptio_sdk_platform_interface_test.dart
+++ b/test/channel/axeptio_sdk_platform_interface_test.dart
@@ -1,18 +1,85 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:axeptio_sdk/src/channel/axeptio_sdk_platform_interface.dart';
-import 'package:axeptio_sdk/src/channel/axeptio_sdk_method_channel.dart';
+import 'package:axeptio_sdk/src/events/event_listener.dart';
+import 'package:axeptio_sdk/src/model/axeptio_service.dart';
+import 'package:axeptio_sdk/src/webview/webview_axeptio_sdk.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   group('AxeptioSdkPlatform', () {
-    test('default instance is MethodChannelAxeptioSdk', () {
-      expect(
-          AxeptioSdkPlatform.instance, isInstanceOf<MethodChannelAxeptioSdk>());
+    test('default instance is WebViewAxeptioSdk', () {
+      expect(AxeptioSdkPlatform.instance, isInstanceOf<WebViewAxeptioSdk>());
     });
 
     test('instance getter returns non-null platform', () {
       expect(AxeptioSdkPlatform.instance, isNotNull);
     });
+
+    test('default instance implements AxeptioSdkPlatform', () {
+      expect(AxeptioSdkPlatform.instance, isA<AxeptioSdkPlatform>());
+    });
+
+    group('default UnimplementedError throws', () {
+      late _StubPlatform stub;
+
+      setUp(() => stub = _StubPlatform());
+
+      test('getPlatformVersion throws', () {
+        expect(() => stub.getPlatformVersion(), throwsUnimplementedError);
+      });
+      test('axeptioToken throws', () {
+        expect(() => stub.axeptioToken, throwsUnimplementedError);
+      });
+      test('initialize throws', () {
+        expect(() => stub.initialize(AxeptioService.publishers, '', '', null),
+            throwsUnimplementedError);
+      });
+      test('setupUI throws', () {
+        expect(() => stub.setupUI(), throwsUnimplementedError);
+      });
+      test('setUserDeniedTracking throws', () {
+        expect(() => stub.setUserDeniedTracking(), throwsUnimplementedError);
+      });
+      test('appendAxeptioTokenURL throws', () {
+        expect(
+            () => stub.appendAxeptioTokenURL('', ''), throwsUnimplementedError);
+      });
+      test('showConsentScreen throws', () {
+        expect(() => stub.showConsentScreen(), throwsUnimplementedError);
+      });
+      test('clearConsent throws', () {
+        expect(() => stub.clearConsent(), throwsUnimplementedError);
+      });
+      test('getConsentSavedData throws', () {
+        expect(() => stub.getConsentSavedData(), throwsUnimplementedError);
+      });
+      test('getConsentDebugInfo throws', () {
+        expect(() => stub.getConsentDebugInfo(), throwsUnimplementedError);
+      });
+      test('getVendorConsents throws', () {
+        expect(() => stub.getVendorConsents(), throwsUnimplementedError);
+      });
+      test('getConsentedVendors throws', () {
+        expect(() => stub.getConsentedVendors(), throwsUnimplementedError);
+      });
+      test('getRefusedVendors throws', () {
+        expect(() => stub.getRefusedVendors(), throwsUnimplementedError);
+      });
+      test('isVendorConsented throws', () {
+        expect(() => stub.isVendorConsented(1), throwsUnimplementedError);
+      });
+      test('addEventListener throws', () {
+        expect(() => stub.addEventListener(AxeptioEventListener()),
+            throwsUnimplementedError);
+      });
+      test('removeEventListener throws', () {
+        expect(() => stub.removeEventListener(AxeptioEventListener()),
+            throwsUnimplementedError);
+      });
+    });
   });
 }
+
+/// Minimal subclass that inherits all default UnimplementedError throws.
+class _StubPlatform extends AxeptioSdkPlatform {}

--- a/test/events/events_handler_test.dart
+++ b/test/events/events_handler_test.dart
@@ -258,6 +258,24 @@ void main() {
         expect(googleConsents, isNotNull);
       });
 
+      test(
+          'listener that removes itself during onPopupClosedEvent does not cause ConcurrentModificationError',
+          () {
+        final listener = AxeptioEventListener();
+        listener.onPopupClosedEvent = () {
+          eventsHandler.removeEventListener(listener);
+        };
+
+        eventsHandler.addEventListener(listener);
+
+        expect(
+          () =>
+              eventsHandler.handleAxeptioEvent({'type': 'onPopupClosedEvent'}),
+          returnsNormally,
+        );
+        expect(eventsHandler.listeners, isEmpty);
+      });
+
       test('listeners can be removed and re-added dynamically', () {
         int callCount = 0;
         final listener = AxeptioEventListener();

--- a/test/events/events_handler_test.dart
+++ b/test/events/events_handler_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:axeptio_sdk/src/events/events_handler.dart';
 import 'package:axeptio_sdk/src/events/event_listener.dart';
@@ -13,33 +12,12 @@ void main() {
     late StreamController<dynamic> eventStreamController;
 
     setUp(() {
-      // Create a stream controller to simulate the event channel
       eventStreamController = StreamController<dynamic>.broadcast();
-
-      // Mock the event channel
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-        const MethodChannel('axeptio_sdk/events'),
-        (MethodCall methodCall) async {
-          if (methodCall.method == 'listen') {
-            return null;
-          }
-          return null;
-        },
-      );
-
-      // We'll directly test the handler methods since mocking EventChannel
-      // broadcast streams is complex in tests
-      eventsHandler = EventsHandler();
+      eventsHandler = EventsHandler(eventStreamController.stream);
     });
 
     tearDown(() {
       eventStreamController.close();
-      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
-          .setMockMethodCallHandler(
-        const MethodChannel('axeptio_sdk/events'),
-        null,
-      );
     });
 
     group('Event Listener Management', () {

--- a/test/gvl/gvl_service_test.dart
+++ b/test/gvl/gvl_service_test.dart
@@ -303,7 +303,7 @@ void main() {
 
     group('VendorInfo equality', () {
       test('two identical VendorInfo are equal', () {
-        final v1 = VendorInfo(
+        const v1 = VendorInfo(
           id: 1,
           name: 'Test',
           consented: true,
@@ -316,7 +316,7 @@ void main() {
           usesNonCookieAccess: false,
           policyUrl: 'https://example.com',
         );
-        final v2 = VendorInfo(
+        const v2 = VendorInfo(
           id: 1,
           name: 'Test',
           consented: true,

--- a/test/gvl/gvl_service_test.dart
+++ b/test/gvl/gvl_service_test.dart
@@ -1,0 +1,336 @@
+import 'dart:convert';
+
+import 'package:axeptio_sdk/src/gvl/gvl_service.dart';
+import 'package:axeptio_sdk/src/model/vendor_info.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const _sampleVendorJson = {
+  'vendors': {
+    '1': {
+      'name': 'Vendor One',
+      'purposes': [1, 2],
+      'legIntPurposes': [3],
+      'specialFeatures': [1],
+      'specialPurposes': [2],
+      'cookieMaxAgeSeconds': 86400,
+      'usesCookies': true,
+      'usesNonCookieAccess': false,
+      'policyUrl': 'https://example.com/privacy',
+      'description': 'Test vendor',
+    },
+    '2': {
+      'name': 'Vendor Two',
+      'purposes': [1],
+      'legIntPurposes': [],
+      'specialFeatures': [],
+      'specialPurposes': [],
+      'usesCookies': false,
+      'usesNonCookieAccess': true,
+    },
+  },
+  'gvlSpecificationVersion': '3',
+};
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late GVLService service;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    // Reset singleton for each test
+    GVLService.resetInstance();
+    service = GVLService.instance;
+  });
+
+  group('GVLService', () {
+    group('loadGVL from cache', () {
+      test('loads successfully from valid cache', () async {
+        final body = jsonEncode(_sampleVendorJson);
+        final nowMs = DateTime.now().millisecondsSinceEpoch;
+        SharedPreferences.setMockInitialValues({
+          'gvl_data': body,
+          'gvl_version': '3',
+          'gvl_timestamp': nowMs,
+        });
+        GVLService.resetInstance();
+        service = GVLService.instance;
+
+        final result = await service.loadGVL();
+
+        expect(result, isTrue);
+        expect(service.isGVLLoaded(), isTrue);
+        expect(service.getGVLVersion(), '3');
+      });
+
+      test('skips expired cache and falls back to remote failure', () async {
+        final expiredMs = DateTime.now()
+            .subtract(const Duration(days: 8))
+            .millisecondsSinceEpoch;
+        SharedPreferences.setMockInitialValues({
+          'gvl_data': jsonEncode(_sampleVendorJson),
+          'gvl_version': '3',
+          'gvl_timestamp': expiredMs,
+        });
+        GVLService.resetInstance();
+        service = GVLService.instance;
+
+        // Without mock HTTP, remote fetch will fail → returns false
+        final result = await service.loadGVL();
+
+        expect(result, isFalse);
+      });
+
+      test('returns false when cache keys are missing', () async {
+        SharedPreferences.setMockInitialValues({'gvl_data': 'some data'});
+        GVLService.resetInstance();
+        service = GVLService.instance;
+
+        final result = await service.loadGVL();
+
+        expect(result, isFalse);
+      });
+    });
+
+    group('loadGVL from remote', () {
+      test('succeeds with 200 response and saves to cache', () async {
+        final body = jsonEncode(_sampleVendorJson);
+        final mockClient = MockClient((_) async => http.Response(body, 200));
+
+        final result = await http.runWithClient(
+          () => service.loadGVL(gvlVersion: '3'),
+          () => mockClient,
+        );
+
+        expect(result, isTrue);
+        expect(service.isGVLLoaded(), isTrue);
+
+        // Verify it was saved to SharedPreferences
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString('gvl_data'), isNotNull);
+        expect(prefs.getString('gvl_version'), isNotNull);
+        expect(prefs.getInt('gvl_timestamp'), isNotNull);
+      });
+
+      test('returns false on non-200 HTTP status', () async {
+        final mockClient =
+            MockClient((_) async => http.Response('Not Found', 404));
+
+        final result = await http.runWithClient(
+          () => service.loadGVL(gvlVersion: 'bad'),
+          () => mockClient,
+        );
+
+        expect(result, isFalse);
+      });
+
+      test('returns false when HTTP throws', () async {
+        final mockClient =
+            MockClient((_) async => throw Exception('Network error'));
+
+        final result = await http.runWithClient(
+          () => service.loadGVL(),
+          () => mockClient,
+        );
+
+        expect(result, isFalse);
+      });
+
+      test('returns false when concurrent load is in progress', () async {
+        // Start a load but don't await it
+        final first = http.runWithClient(
+          () => service.loadGVL(gvlVersion: '3'),
+          () => MockClient((_) async {
+            await Future.delayed(const Duration(milliseconds: 50));
+            return http.Response(jsonEncode(_sampleVendorJson), 200);
+          }),
+        );
+        // Second call while first is in progress
+        final second = service.loadGVL();
+        expect(await second, isFalse);
+        await first;
+      });
+
+      test('parses extended vendor fields correctly', () async {
+        final body = jsonEncode(_sampleVendorJson);
+        final mockClient = MockClient((_) async => http.Response(body, 200));
+
+        await http.runWithClient(
+          () => service.loadGVL(gvlVersion: '3'),
+          () => mockClient,
+        );
+
+        final vendor = service.getVendorInfo(1);
+        expect(vendor, isNotNull);
+        expect(vendor!.legitimateInterestPurposes, [3]);
+        expect(vendor.specialFeatures, [1]);
+        expect(vendor.specialPurposes, [2]);
+        expect(vendor.cookieMaxAgeSeconds, 86400);
+        expect(vendor.usesCookies, isTrue);
+        expect(vendor.usesNonCookieAccess, isFalse);
+        expect(vendor.policyUrl, 'https://example.com/privacy');
+      });
+
+      test('handles malformed vendors JSON gracefully', () async {
+        final badJson = jsonEncode({'vendors': 'not_a_map'});
+        final mockClient = MockClient((_) async => http.Response(badJson, 200));
+
+        final result = await http.runWithClient(
+          () => service.loadGVL(gvlVersion: '3'),
+          () => mockClient,
+        );
+
+        // Service should not crash; vendors might be empty
+        expect(result, isTrue);
+      });
+
+      test('uses tcfPolicyVersion as fallback version', () async {
+        final body = jsonEncode({
+          'vendors': {},
+          'tcfPolicyVersion': '4',
+        });
+        final mockClient = MockClient((_) async => http.Response(body, 200));
+
+        await http.runWithClient(
+          () => service.loadGVL(gvlVersion: '4'),
+          () => mockClient,
+        );
+
+        expect(service.getGVLVersion(), '4');
+      });
+    });
+
+    group('getVendorInfo', () {
+      test('returns null when not loaded', () {
+        expect(service.getVendorInfo(1), isNull);
+      });
+
+      test('returns VendorInfo after loading', () async {
+        final mockClient = MockClient(
+            (_) async => http.Response(jsonEncode(_sampleVendorJson), 200));
+        await http.runWithClient(
+          () => service.loadGVL(gvlVersion: '3'),
+          () => mockClient,
+        );
+
+        final info = service.getVendorInfo(1);
+        expect(info, isNotNull);
+        expect(info!.name, 'Vendor One');
+      });
+
+      test('returns null for unknown vendor', () async {
+        final mockClient = MockClient(
+            (_) async => http.Response(jsonEncode(_sampleVendorJson), 200));
+        await http.runWithClient(
+          () => service.loadGVL(gvlVersion: '3'),
+          () => mockClient,
+        );
+
+        expect(service.getVendorInfo(999), isNull);
+      });
+    });
+
+    group('getAllVendors', () {
+      test('returns empty map when not loaded', () {
+        expect(service.getAllVendors(), isEmpty);
+      });
+
+      test('returns all vendors after loading', () async {
+        final mockClient = MockClient(
+            (_) async => http.Response(jsonEncode(_sampleVendorJson), 200));
+        await http.runWithClient(
+          () => service.loadGVL(gvlVersion: '3'),
+          () => mockClient,
+        );
+
+        final all = service.getAllVendors();
+        expect(all, hasLength(2));
+        expect(all[1]!.name, 'Vendor One');
+        expect(all[2]!.name, 'Vendor Two');
+      });
+    });
+
+    group('clearGVL', () {
+      test('clears cache from SharedPreferences', () async {
+        final body = jsonEncode(_sampleVendorJson);
+        SharedPreferences.setMockInitialValues({
+          'gvl_data': body,
+          'gvl_version': '3',
+          'gvl_timestamp': DateTime.now().millisecondsSinceEpoch,
+        });
+        GVLService.resetInstance();
+        service = GVLService.instance;
+        await service.loadGVL();
+
+        await service.clearGVL();
+
+        expect(service.isGVLLoaded(), isFalse);
+        final prefs = await SharedPreferences.getInstance();
+        expect(prefs.getString('gvl_data'), isNull);
+        expect(prefs.getString('gvl_version'), isNull);
+        expect(prefs.getInt('gvl_timestamp'), isNull);
+      });
+    });
+
+    group('createVendorConsentsWithNames', () {
+      test('returns empty map when GVL not loaded', () {
+        final result =
+            service.createVendorConsentsWithNames({1: true, 2: false});
+        expect(result, isEmpty);
+      });
+
+      test('creates fallback VendorInfo for unknown vendors', () async {
+        final mockClient = MockClient(
+            (_) async => http.Response(jsonEncode(_sampleVendorJson), 200));
+        await http.runWithClient(
+          () => service.loadGVL(gvlVersion: '3'),
+          () => mockClient,
+        );
+
+        final result = service.createVendorConsentsWithNames({
+          1: true, // Known vendor
+          999: false, // Unknown vendor
+        });
+
+        expect(result[999]!.name, 'Vendor 999');
+        expect(result[999]!.consented, isFalse);
+        expect(result[1]!.name, 'Vendor One');
+      });
+    });
+
+    group('VendorInfo equality', () {
+      test('two identical VendorInfo are equal', () {
+        final v1 = VendorInfo(
+          id: 1,
+          name: 'Test',
+          consented: true,
+          purposes: [1, 2],
+          legitimateInterestPurposes: [3],
+          specialFeatures: [4],
+          specialPurposes: [5],
+          cookieMaxAgeSeconds: 100,
+          usesCookies: true,
+          usesNonCookieAccess: false,
+          policyUrl: 'https://example.com',
+        );
+        final v2 = VendorInfo(
+          id: 1,
+          name: 'Test',
+          consented: true,
+          purposes: [1, 2],
+          legitimateInterestPurposes: [3],
+          specialFeatures: [4],
+          specialPurposes: [5],
+          cookieMaxAgeSeconds: 100,
+          usesCookies: true,
+          usesNonCookieAccess: false,
+          policyUrl: 'https://example.com',
+        );
+        expect(v1, equals(v2));
+      });
+    });
+  });
+}

--- a/test/webview/axeptio_consent_view_test.dart
+++ b/test/webview/axeptio_consent_view_test.dart
@@ -9,8 +9,17 @@ import 'package:webview_flutter_platform_interface/webview_flutter_platform_inte
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  WebViewPlatform? savedWebViewPlatform;
+
   setUp(() {
+    savedWebViewPlatform = WebViewPlatform.instance;
     WebViewPlatform.instance = _MockWebViewPlatform();
+  });
+
+  tearDown(() {
+    if (savedWebViewPlatform != null) {
+      WebViewPlatform.instance = savedWebViewPlatform!;
+    }
   });
 
   final testUri = Uri.parse('https://static.axept.io/test.html');

--- a/test/webview/axeptio_consent_view_test.dart
+++ b/test/webview/axeptio_consent_view_test.dart
@@ -10,9 +10,17 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   WebViewPlatform? savedWebViewPlatform;
+  WebViewPlatform? originalWebViewPlatform;
 
   setUpAll(() {
+    originalWebViewPlatform = WebViewPlatform.instance;
     WebViewPlatform.instance = _MockWebViewPlatform();
+  });
+
+  tearDownAll(() {
+    if (originalWebViewPlatform != null) {
+      WebViewPlatform.instance = originalWebViewPlatform!;
+    }
   });
 
   setUp(() {

--- a/test/webview/axeptio_consent_view_test.dart
+++ b/test/webview/axeptio_consent_view_test.dart
@@ -11,15 +11,17 @@ void main() {
 
   WebViewPlatform? savedWebViewPlatform;
 
+  setUpAll(() {
+    WebViewPlatform.instance = _MockWebViewPlatform();
+  });
+
   setUp(() {
     savedWebViewPlatform = WebViewPlatform.instance;
     WebViewPlatform.instance = _MockWebViewPlatform();
   });
 
   tearDown(() {
-    if (savedWebViewPlatform != null) {
-      WebViewPlatform.instance = savedWebViewPlatform!;
-    }
+    WebViewPlatform.instance = savedWebViewPlatform!;
   });
 
   final testUri = Uri.parse('https://static.axept.io/test.html');

--- a/test/webview/axeptio_consent_view_test.dart
+++ b/test/webview/axeptio_consent_view_test.dart
@@ -1,0 +1,341 @@
+import 'dart:convert';
+
+import 'package:axeptio_sdk/src/webview/axeptio_consent_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    WebViewPlatform.instance = _MockWebViewPlatform();
+  });
+
+  final testUri = Uri.parse('https://static.axept.io/test.html');
+
+  group('AxeptioConsentView widget', () {
+    testWidgets('renders Scaffold with WebViewWidget', (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          consentUrl: testUri,
+          onJsEvent: (_, __) {},
+          onClose: () {},
+        ),
+      ));
+
+      expect(find.byType(Scaffold), findsOneWidget);
+      expect(find.byType(WebViewWidget), findsOneWidget);
+    });
+
+    testWidgets('accepts attDenied and storedTcString parameters',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          consentUrl: testUri,
+          onJsEvent: (_, __) {},
+          onClose: () {},
+          attDenied: true,
+          storedTcString: 'CPXxRfAP',
+        ),
+      ));
+      expect(find.byType(AxeptioConsentView), findsOneWidget);
+    });
+
+    testWidgets('has correct default values', (tester) async {
+      AxeptioConsentView? w;
+      await tester.pumpWidget(MaterialApp(
+        home: Builder(builder: (ctx) {
+          w = AxeptioConsentView(
+            consentUrl: testUri,
+            onJsEvent: (_, __) {},
+            onClose: () {},
+          );
+          return w!;
+        }),
+      ));
+      expect(w!.attDenied, isFalse);
+      expect(w!.storedTcString, isNull);
+    });
+  });
+
+  group('AxeptioConsentViewState JS message handling', () {
+    late GlobalKey<AxeptioConsentViewState> stateKey;
+    late List<String> jsEvents;
+    late int closeCount;
+
+    setUp(() {
+      stateKey = GlobalKey<AxeptioConsentViewState>();
+      jsEvents = [];
+      closeCount = 0;
+    });
+
+    Future<void> buildWidget(WidgetTester tester,
+        {bool attDenied = false, String? storedTcString}) async {
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          key: stateKey,
+          consentUrl: testUri,
+          onJsEvent: (name, _) => jsEvents.add(name),
+          onClose: () => closeCount++,
+          attDenied: attDenied,
+          storedTcString: storedTcString,
+        ),
+      ));
+    }
+
+    testWidgets('simulatePageFinished runs without error', (tester) async {
+      await buildWidget(tester);
+      await expectLater(
+          stateKey.currentState!.simulatePageFinished(), completes);
+    });
+
+    testWidgets('simulatePageFinished with attDenied', (tester) async {
+      await buildWidget(tester, attDenied: true);
+      await expectLater(
+          stateKey.currentState!.simulatePageFinished(), completes);
+    });
+
+    testWidgets('simulatePageFinished with storedTcString', (tester) async {
+      await buildWidget(tester, storedTcString: 'CPXx');
+      await expectLater(
+          stateKey.currentState!.simulatePageFinished(), completes);
+    });
+
+    testWidgets('unknown event fires onJsEvent callback', (tester) async {
+      await buildWidget(tester);
+      stateKey.currentState!.simulateJsMessage(
+          jsonEncode({'name': 'some:event', 'payload': null}));
+      expect(jsEvents, contains('some:event'));
+    });
+
+    testWidgets('cookies:close fires onJsEvent and onClose', (tester) async {
+      await buildWidget(tester);
+      stateKey.currentState!.simulateJsMessage(
+          jsonEncode({'name': 'cookies:close', 'payload': null}));
+      expect(jsEvents, contains('cookies:close'));
+      expect(closeCount, 1);
+    });
+
+    testWidgets('app:cookies:ready with subscription==false calls onClose',
+        (tester) async {
+      await buildWidget(tester);
+      stateKey.currentState!.simulateJsMessage(jsonEncode({
+        'name': 'app:cookies:ready',
+        'payload': jsonEncode({'subscription': false, 'showCmp': true})
+      }));
+      expect(closeCount, 1);
+    });
+
+    testWidgets('app:cookies:ready with showCmp==false calls onClose',
+        (tester) async {
+      await buildWidget(tester);
+      stateKey.currentState!.simulateJsMessage(jsonEncode({
+        'name': 'app:cookies:ready',
+        'payload': jsonEncode({'subscription': null, 'showCmp': false})
+      }));
+      expect(closeCount, 1);
+    });
+
+    testWidgets('app:cookies:ready with showCmp==true does NOT close',
+        (tester) async {
+      await buildWidget(tester);
+      stateKey.currentState!.simulateJsMessage(jsonEncode({
+        'name': 'app:cookies:ready',
+        'payload': jsonEncode({'subscription': null, 'showCmp': true})
+      }));
+      expect(closeCount, 0);
+    });
+
+    testWidgets('app:cookies:ready with null payload calls onClose',
+        (tester) async {
+      await buildWidget(tester);
+      stateKey.currentState!.simulateJsMessage(
+          jsonEncode({'name': 'app:cookies:ready', 'payload': null}));
+      expect(closeCount, 1);
+    });
+
+    testWidgets('payload as Map (not string) is handled', (tester) async {
+      await buildWidget(tester);
+      stateKey.currentState!.simulateJsMessage(jsonEncode({
+        'name': 'some:event',
+        'payload': {'key': 'value'}
+      }));
+      expect(jsEvents, contains('some:event'));
+    });
+
+    testWidgets('message with null name is ignored', (tester) async {
+      await buildWidget(tester);
+      stateKey.currentState!
+          .simulateJsMessage(jsonEncode({'name': null, 'payload': null}));
+      expect(jsEvents, isEmpty);
+      expect(closeCount, 0);
+    });
+
+    testWidgets('invalid JSON is silently ignored', (tester) async {
+      await buildWidget(tester);
+      expect(() => stateKey.currentState!.simulateJsMessage('not valid json'),
+          returnsNormally);
+      expect(jsEvents, isEmpty);
+    });
+  });
+}
+
+// Minimal mock WebView platform
+class _MockWebViewPlatform extends WebViewPlatform {
+  @override
+  PlatformWebViewController createPlatformWebViewController(
+      PlatformWebViewControllerCreationParams params) {
+    return _MockWebViewController(params);
+  }
+
+  @override
+  PlatformWebViewWidget createPlatformWebViewWidget(
+      PlatformWebViewWidgetCreationParams params) {
+    return _MockWebViewWidget(params);
+  }
+
+  @override
+  PlatformWebViewCookieManager createPlatformCookieManager(
+      PlatformWebViewCookieManagerCreationParams params) {
+    return _MockCookieManager(params);
+  }
+
+  @override
+  PlatformNavigationDelegate createPlatformNavigationDelegate(
+      PlatformNavigationDelegateCreationParams params) {
+    return _MockNavigationDelegate(params);
+  }
+}
+
+class _MockWebViewController extends PlatformWebViewController {
+  _MockWebViewController(super.params) : super.implementation();
+
+  @override
+  Future<void> setJavaScriptMode(JavaScriptMode javaScriptMode) async {}
+
+  @override
+  Future<void> setBackgroundColor(Color color) async {}
+
+  @override
+  Future<void> setPlatformNavigationDelegate(
+      PlatformNavigationDelegate handler) async {}
+
+  @override
+  Future<void> addJavaScriptChannel(
+      JavaScriptChannelParams javaScriptChannelParams) async {}
+
+  @override
+  Future<void> removeJavaScriptChannel(String javaScriptChannelName) async {}
+
+  @override
+  Future<void> loadRequest(LoadRequestParams params) async {}
+
+  @override
+  Future<void> loadHtmlString(String html, {String? baseUrl}) async {}
+
+  @override
+  Future<void> loadFile(String absoluteFilePath) async {}
+
+  @override
+  Future<void> loadFlutterAsset(String key) async {}
+
+  @override
+  Future<String?> currentUrl() async => null;
+
+  @override
+  Future<bool> canGoBack() async => false;
+
+  @override
+  Future<bool> canGoForward() async => false;
+
+  @override
+  Future<void> goBack() async {}
+
+  @override
+  Future<void> goForward() async {}
+
+  @override
+  Future<void> reload() async {}
+
+  @override
+  Future<void> clearCache() async {}
+
+  @override
+  Future<void> clearLocalStorage() async {}
+
+  @override
+  Future<void> runJavaScript(String javaScript) async {}
+
+  @override
+  Future<Object> runJavaScriptReturningResult(String javaScript) async => '';
+
+  @override
+  Future<String?> getTitle() async => null;
+
+  @override
+  Future<void> scrollTo(int x, int y) async {}
+
+  @override
+  Future<void> scrollBy(int x, int y) async {}
+
+  @override
+  Future<Offset> getScrollPosition() async => Offset.zero;
+
+  @override
+  Future<void> enableZoom(bool enabled) async {}
+
+  Future<void> setCustomUserAgent(String? userAgent) async {}
+
+  @override
+  Future<String?> getUserAgent() async => null;
+}
+
+class _MockWebViewWidget extends PlatformWebViewWidget {
+  _MockWebViewWidget(super.params) : super.implementation();
+
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+class _MockCookieManager extends PlatformWebViewCookieManager {
+  _MockCookieManager(super.params) : super.implementation();
+
+  @override
+  Future<bool> clearCookies() async => true;
+
+  @override
+  Future<void> setCookie(WebViewCookie cookie) async {}
+}
+
+class _MockNavigationDelegate extends PlatformNavigationDelegate {
+  _MockNavigationDelegate(super.params) : super.implementation();
+
+  @override
+  Future<void> setOnNavigationRequest(
+      NavigationRequestCallback onNavigationRequest) async {}
+
+  @override
+  Future<void> setOnPageStarted(PageEventCallback onPageStarted) async {}
+
+  @override
+  Future<void> setOnPageFinished(PageEventCallback onPageFinished) async {}
+
+  @override
+  Future<void> setOnProgress(ProgressCallback onProgress) async {}
+
+  @override
+  Future<void> setOnWebResourceError(
+      WebResourceErrorCallback onWebResourceError) async {}
+
+  @override
+  Future<void> setOnUrlChange(UrlChangeCallback onUrlChange) async {}
+
+  @override
+  Future<void> setOnHttpAuthRequest(
+      HttpAuthRequestCallback onHttpAuthRequest) async {}
+
+  @override
+  Future<void> setOnHttpError(HttpResponseErrorCallback onHttpError) async {}
+}

--- a/test/webview/axeptio_consent_view_test.dart
+++ b/test/webview/axeptio_consent_view_test.dart
@@ -148,6 +148,26 @@ void main() {
       expect(closeCount, 0);
     });
 
+    testWidgets(
+        'app:cookies:ready with showConsentManager==true bypasses showCmp check',
+        (tester) async {
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          key: stateKey,
+          consentUrl: testUri,
+          onJsEvent: (name, _) => jsEvents.add(name),
+          onClose: () => closeCount++,
+          showConsentManager: true,
+        ),
+      ));
+      stateKey.currentState!.simulateJsMessage(jsonEncode({
+        'name': 'app:cookies:ready',
+        'payload': jsonEncode({'subscription': null, 'showCmp': false})
+      }));
+      // Should NOT close — showConsentManager forces the CMP to show
+      expect(closeCount, 0);
+    });
+
     testWidgets('app:cookies:ready with null payload calls onClose',
         (tester) async {
       await buildWidget(tester);

--- a/test/webview/consent_url_builder_test.dart
+++ b/test/webview/consent_url_builder_test.dart
@@ -91,39 +91,39 @@ void main() {
   group('ConsentUrlBuilder.appendToken', () {
     test('appends clientId and cookiesVersion to URL', () {
       final uri = ConsentUrlBuilder.appendToken(
-          'https://example.com', 'cid', 'cv', null);
+          'https://example.com', 'cid', 'cv', null)!;
       expect(uri.queryParameters['clientId'], 'cid');
       expect(uri.queryParameters['cookiesVersion'], 'cv');
     });
 
     test('appends token when provided', () {
       final uri = ConsentUrlBuilder.appendToken(
-          'https://example.com', 'cid', 'cv', 'tok');
+          'https://example.com', 'cid', 'cv', 'tok')!;
       expect(uri.queryParameters['axeptio_token'], 'tok');
     });
 
     test('omits token param when null', () {
       final uri = ConsentUrlBuilder.appendToken(
-          'https://example.com', 'cid', 'cv', null);
+          'https://example.com', 'cid', 'cv', null)!;
       expect(uri.queryParameters.containsKey('axeptio_token'), isFalse);
     });
 
     test('removes existing axeptio_token from url when token is null', () {
       final uri = ConsentUrlBuilder.appendToken(
-          'https://example.com?axeptio_token=old', 'cid', 'cv', null);
+          'https://example.com?axeptio_token=old', 'cid', 'cv', null)!;
       expect(uri.queryParameters.containsKey('axeptio_token'), isFalse);
     });
 
     test('preserves existing query params', () {
       final uri = ConsentUrlBuilder.appendToken(
-          'https://example.com?foo=bar', 'cid', 'cv', 'tok');
+          'https://example.com?foo=bar', 'cid', 'cv', 'tok')!;
       expect(uri.queryParameters['foo'], 'bar');
       expect(uri.queryParameters['clientId'], 'cid');
     });
 
     test('preserves host and path', () {
       final uri = ConsentUrlBuilder.appendToken(
-          'https://mysite.com/path/page', 'cid', 'cv', null);
+          'https://mysite.com/path/page', 'cid', 'cv', null)!;
       expect(uri.host, 'mysite.com');
       expect(uri.path, '/path/page');
     });
@@ -131,7 +131,7 @@ void main() {
     test('overrides existing clientId if present', () {
       final uri = ConsentUrlBuilder.appendToken(
           'https://example.com?clientId=old', 'new-cid', 'cv', null);
-      expect(uri.queryParameters['clientId'], 'new-cid');
+      expect(uri!.queryParameters['clientId'], 'new-cid');
     });
   });
 }

--- a/test/webview/consent_url_builder_test.dart
+++ b/test/webview/consent_url_builder_test.dart
@@ -1,0 +1,131 @@
+import 'package:axeptio_sdk/src/model/axeptio_service.dart';
+import 'package:axeptio_sdk/src/webview/consent_url_builder.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ConsentUrlBuilder.build', () {
+    test('publishers service uses correct base URL', () {
+      final uri = ConsentUrlBuilder.build(
+        service: AxeptioService.publishers,
+        clientId: 'client123',
+        cookiesVersion: 'v1',
+      );
+      expect(uri.host, 'static.axept.io');
+      expect(uri.path, '/app-sdk-webview.html');
+    });
+
+    test('brands service uses correct base URL', () {
+      final uri = ConsentUrlBuilder.build(
+        service: AxeptioService.brands,
+        clientId: 'client123',
+        cookiesVersion: 'v1',
+      );
+      expect(uri.host, 'static.axept.io');
+      expect(uri.path, '/app-sdk-webview-for-brands.html');
+    });
+
+    test('includes required query params', () {
+      final uri = ConsentUrlBuilder.build(
+        service: AxeptioService.publishers,
+        clientId: 'my-client',
+        cookiesVersion: 'my-version',
+      );
+      expect(uri.queryParameters['clientId'], 'my-client');
+      expect(uri.queryParameters['cookiesVersion'], 'my-version');
+    });
+
+    test('includes token when provided', () {
+      final uri = ConsentUrlBuilder.build(
+        service: AxeptioService.publishers,
+        clientId: 'c',
+        cookiesVersion: 'v',
+        token: 'tok-abc',
+      );
+      expect(uri.queryParameters['axeptio_token'], 'tok-abc');
+    });
+
+    test('omits token param when not provided', () {
+      final uri = ConsentUrlBuilder.build(
+        service: AxeptioService.publishers,
+        clientId: 'c',
+        cookiesVersion: 'v',
+      );
+      expect(uri.queryParameters.containsKey('axeptio_token'), isFalse);
+    });
+
+    test('includes showConsentManager when true', () {
+      final uri = ConsentUrlBuilder.build(
+        service: AxeptioService.publishers,
+        clientId: 'c',
+        cookiesVersion: 'v',
+        showConsentManager: true,
+      );
+      expect(uri.queryParameters['showConsentManager'], 'true');
+    });
+
+    test('omits showConsentManager when false', () {
+      final uri = ConsentUrlBuilder.build(
+        service: AxeptioService.publishers,
+        clientId: 'c',
+        cookiesVersion: 'v',
+        showConsentManager: false,
+      );
+      expect(uri.queryParameters.containsKey('showConsentManager'), isFalse);
+    });
+
+    test('all params combined', () {
+      final uri = ConsentUrlBuilder.build(
+        service: AxeptioService.brands,
+        clientId: 'cid',
+        cookiesVersion: 'cv',
+        token: 'tok',
+        showConsentManager: true,
+      );
+      expect(uri.queryParameters['clientId'], 'cid');
+      expect(uri.queryParameters['cookiesVersion'], 'cv');
+      expect(uri.queryParameters['axeptio_token'], 'tok');
+      expect(uri.queryParameters['showConsentManager'], 'true');
+    });
+  });
+
+  group('ConsentUrlBuilder.appendToken', () {
+    test('appends clientId and cookiesVersion to URL', () {
+      final uri = ConsentUrlBuilder.appendToken(
+          'https://example.com', 'cid', 'cv', null);
+      expect(uri.queryParameters['clientId'], 'cid');
+      expect(uri.queryParameters['cookiesVersion'], 'cv');
+    });
+
+    test('appends token when provided', () {
+      final uri = ConsentUrlBuilder.appendToken(
+          'https://example.com', 'cid', 'cv', 'tok');
+      expect(uri.queryParameters['axeptio_token'], 'tok');
+    });
+
+    test('omits token param when null', () {
+      final uri = ConsentUrlBuilder.appendToken(
+          'https://example.com', 'cid', 'cv', null);
+      expect(uri.queryParameters.containsKey('axeptio_token'), isFalse);
+    });
+
+    test('preserves existing query params', () {
+      final uri = ConsentUrlBuilder.appendToken(
+          'https://example.com?foo=bar', 'cid', 'cv', 'tok');
+      expect(uri.queryParameters['foo'], 'bar');
+      expect(uri.queryParameters['clientId'], 'cid');
+    });
+
+    test('preserves host and path', () {
+      final uri = ConsentUrlBuilder.appendToken(
+          'https://mysite.com/path/page', 'cid', 'cv', null);
+      expect(uri.host, 'mysite.com');
+      expect(uri.path, '/path/page');
+    });
+
+    test('overrides existing clientId if present', () {
+      final uri = ConsentUrlBuilder.appendToken(
+          'https://example.com?clientId=old', 'new-cid', 'cv', null);
+      expect(uri.queryParameters['clientId'], 'new-cid');
+    });
+  });
+}

--- a/test/webview/consent_url_builder_test.dart
+++ b/test/webview/consent_url_builder_test.dart
@@ -108,6 +108,12 @@ void main() {
       expect(uri.queryParameters.containsKey('axeptio_token'), isFalse);
     });
 
+    test('removes existing axeptio_token from url when token is null', () {
+      final uri = ConsentUrlBuilder.appendToken(
+          'https://example.com?axeptio_token=old', 'cid', 'cv', null);
+      expect(uri.queryParameters.containsKey('axeptio_token'), isFalse);
+    });
+
     test('preserves existing query params', () {
       final uri = ConsentUrlBuilder.appendToken(
           'https://example.com?foo=bar', 'cid', 'cv', 'tok');

--- a/test/webview/tcf_storage_test.dart
+++ b/test/webview/tcf_storage_test.dart
@@ -40,11 +40,18 @@ void main() {
         expect(storage.axeptioToken, isNull);
       });
 
-      test('returns stored token', () async {
-        SharedPreferences.setMockInitialValues({'_ax_token': 'tok-123'});
+      test('returns stored token from AX_CLIENT_TOKEN key', () async {
+        SharedPreferences.setMockInitialValues({'AX_CLIENT_TOKEN': 'tok-123'});
         final prefs = await SharedPreferences.getInstance();
         final s = TcfStorage(prefs);
         expect(s.axeptioToken, 'tok-123');
+      });
+
+      test('falls back to legacy _ax_token key for migration', () async {
+        SharedPreferences.setMockInitialValues({'_ax_token': 'legacy-tok'});
+        final prefs = await SharedPreferences.getInstance();
+        final s = TcfStorage(prefs);
+        expect(s.axeptioToken, 'legacy-tok');
       });
     });
 
@@ -89,7 +96,7 @@ void main() {
     });
 
     group('writeConsentSaved', () {
-      test('stores axeptio_token', () async {
+      test('stores axeptio_token under AX_CLIENT_TOKEN key', () async {
         await storage.writeConsentSaved({'axeptio_token': 'my-token'});
         expect(storage.axeptioToken, 'my-token');
       });
@@ -178,7 +185,7 @@ void main() {
         await storage.writeConsentSaved({'axeptio_token': 'tok'});
         final all = storage.getAllData();
         expect(all['IABTCF_TCString'], 'CPXx');
-        expect(all['_ax_token'], 'tok');
+        expect(all['AX_CLIENT_TOKEN'], 'tok');
       });
     });
 

--- a/test/webview/tcf_storage_test.dart
+++ b/test/webview/tcf_storage_test.dart
@@ -128,6 +128,16 @@ void main() {
         final all = storage.getAllData();
         expect(all.containsKey('axeptio_cookies'), isFalse);
       });
+
+      test('clears legacy _ax_token when writing new token', () async {
+        SharedPreferences.setMockInitialValues({'_ax_token': 'legacy-tok'});
+        final prefs = await SharedPreferences.getInstance();
+        final s = TcfStorage(prefs);
+        await s.writeConsentSaved({'axeptio_token': 'new-tok'});
+        final all = s.getAllData();
+        expect(all.containsKey('_ax_token'), isFalse);
+        expect(s.axeptioToken, 'new-tok');
+      });
     });
 
     group('writeCookies', () {
@@ -173,6 +183,14 @@ void main() {
         expect(storage.tcString, isNull);
         expect(storage.axeptioToken, isNull);
       });
+
+      test('clears AX_POPUP_ON_GOING key', () async {
+        SharedPreferences.setMockInitialValues({'AX_POPUP_ON_GOING': true});
+        final prefs = await SharedPreferences.getInstance();
+        final s = TcfStorage(prefs);
+        await s.clearAll();
+        expect(s.getAllData().containsKey('AX_POPUP_ON_GOING'), isFalse);
+      });
     });
 
     group('getAllData', () {
@@ -194,6 +212,13 @@ void main() {
         final s = TcfStorage(prefs);
         final all = s.getAllData();
         expect(all['_ax_token'], 'legacy-tok');
+      });
+
+      test('includes AX_POPUP_ON_GOING when set', () async {
+        SharedPreferences.setMockInitialValues({'AX_POPUP_ON_GOING': true});
+        final prefs = await SharedPreferences.getInstance();
+        final s = TcfStorage(prefs);
+        expect(s.getAllData()['AX_POPUP_ON_GOING'], isTrue);
       });
     });
 

--- a/test/webview/tcf_storage_test.dart
+++ b/test/webview/tcf_storage_test.dart
@@ -187,6 +187,14 @@ void main() {
         expect(all['IABTCF_TCString'], 'CPXx');
         expect(all['AX_CLIENT_TOKEN'], 'tok');
       });
+
+      test('includes legacy _ax_token when only that key is present', () async {
+        SharedPreferences.setMockInitialValues({'_ax_token': 'legacy-tok'});
+        final prefs = await SharedPreferences.getInstance();
+        final s = TcfStorage(prefs);
+        final all = s.getAllData();
+        expect(all['_ax_token'], 'legacy-tok');
+      });
     });
 
     group('getVendorConsents', () {

--- a/test/webview/tcf_storage_test.dart
+++ b/test/webview/tcf_storage_test.dart
@@ -1,0 +1,224 @@
+import 'package:axeptio_sdk/src/webview/tcf_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TcfStorage', () {
+    late TcfStorage storage;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      final prefs = await SharedPreferences.getInstance();
+      storage = TcfStorage(prefs);
+    });
+
+    group('create()', () {
+      test('creates instance via shared preferences', () async {
+        SharedPreferences.setMockInitialValues({});
+        final s = await TcfStorage.create();
+        expect(s, isA<TcfStorage>());
+      });
+    });
+
+    group('tcString getter', () {
+      test('returns null when not set', () {
+        expect(storage.tcString, isNull);
+      });
+
+      test('returns stored value', () async {
+        SharedPreferences.setMockInitialValues({'IABTCF_TCString': 'CPXxRfAP'});
+        final prefs = await SharedPreferences.getInstance();
+        final s = TcfStorage(prefs);
+        expect(s.tcString, 'CPXxRfAP');
+      });
+    });
+
+    group('axeptioToken getter', () {
+      test('returns null when not set', () {
+        expect(storage.axeptioToken, isNull);
+      });
+
+      test('returns stored token', () async {
+        SharedPreferences.setMockInitialValues({'_ax_token': 'tok-123'});
+        final prefs = await SharedPreferences.getInstance();
+        final s = TcfStorage(prefs);
+        expect(s.axeptioToken, 'tok-123');
+      });
+    });
+
+    group('writeIabTcfFields', () {
+      test('writes string fields', () async {
+        await storage.writeIabTcfFields({'IABTCF_TCString': 'CPXxRfAP'});
+        expect(storage.tcString, 'CPXxRfAP');
+      });
+
+      test('writes bool fields', () async {
+        await storage.writeIabTcfFields({'IABTCF_gdprApplies': true});
+        final all = storage.getAllData();
+        expect(all['IABTCF_gdprApplies'], true);
+      });
+
+      test('writes int fields', () async {
+        await storage.writeIabTcfFields({'IABTCF_CmpSdkID': 42});
+        final all = storage.getAllData();
+        expect(all['IABTCF_CmpSdkID'], 42);
+      });
+
+      test('skips null values', () async {
+        await storage.writeIabTcfFields({'IABTCF_TCString': null});
+        expect(storage.tcString, isNull);
+      });
+
+      test('does nothing when payload is null', () async {
+        await expectLater(storage.writeIabTcfFields(null), completes);
+      });
+
+      test('writes multiple fields', () async {
+        await storage.writeIabTcfFields({
+          'IABTCF_TCString': 'CPXx',
+          'IABTCF_gdprApplies': true,
+          'IABTCF_CmpSdkID': 1,
+        });
+        final all = storage.getAllData();
+        expect(all['IABTCF_TCString'], 'CPXx');
+        expect(all['IABTCF_gdprApplies'], true);
+        expect(all['IABTCF_CmpSdkID'], 1);
+      });
+    });
+
+    group('writeConsentSaved', () {
+      test('stores axeptio_token', () async {
+        await storage.writeConsentSaved({'axeptio_token': 'my-token'});
+        expect(storage.axeptioToken, 'my-token');
+      });
+
+      test('stores axeptio_cookies', () async {
+        await storage.writeConsentSaved({'axeptio_cookies': '{"a":true}'});
+        final all = storage.getAllData();
+        expect(all['axeptio_cookies'], '{"a":true}');
+      });
+
+      test('stores axeptio_all_vendors', () async {
+        await storage.writeConsentSaved({'axeptio_all_vendors': 'v1,v2'});
+        final all = storage.getAllData();
+        expect(all['axeptio_all_vendors'], 'v1,v2');
+      });
+
+      test('stores axeptio_authorized_vendors', () async {
+        await storage.writeConsentSaved({'axeptio_authorized_vendors': 'v1'});
+        final all = storage.getAllData();
+        expect(all['axeptio_authorized_vendors'], 'v1');
+      });
+
+      test('does nothing when null', () async {
+        await expectLater(storage.writeConsentSaved(null), completes);
+      });
+
+      test('skips missing keys gracefully', () async {
+        await storage.writeConsentSaved({'axeptio_token': 'tok'});
+        final all = storage.getAllData();
+        expect(all.containsKey('axeptio_cookies'), isFalse);
+      });
+    });
+
+    group('writeCookies', () {
+      test('writes cookie key-value pairs', () async {
+        await storage.writeCookies({'axeptio_cookies': 'data'});
+        final all = storage.getAllData();
+        expect(all['axeptio_cookies'], 'data');
+      });
+
+      test('does nothing when null', () async {
+        await expectLater(storage.writeCookies(null), completes);
+      });
+    });
+
+    group('writeScope', () {
+      test('stores widget_scope', () async {
+        await storage.writeScope({'scope': 'persistent'});
+        final all = storage.getAllData();
+        expect(all['widget_scope'], 'persistent');
+      });
+
+      test('does nothing when null', () async {
+        await expectLater(storage.writeScope(null), completes);
+      });
+
+      test('skips when scope key is absent', () async {
+        await storage.writeScope({'other': 'value'});
+        final all = storage.getAllData();
+        expect(all.containsKey('widget_scope'), isFalse);
+      });
+    });
+
+    group('clearAll', () {
+      test('removes all stored keys', () async {
+        await storage.writeIabTcfFields({'IABTCF_TCString': 'CPXx'});
+        await storage.writeConsentSaved({'axeptio_token': 'tok'});
+        await storage.writeScope({'scope': 'session'});
+
+        await storage.clearAll();
+
+        final all = storage.getAllData();
+        expect(all, isEmpty);
+        expect(storage.tcString, isNull);
+        expect(storage.axeptioToken, isNull);
+      });
+    });
+
+    group('getAllData', () {
+      test('returns empty map when nothing stored', () {
+        expect(storage.getAllData(), isEmpty);
+      });
+
+      test('returns stored values', () async {
+        await storage.writeIabTcfFields({'IABTCF_TCString': 'CPXx'});
+        await storage.writeConsentSaved({'axeptio_token': 'tok'});
+        final all = storage.getAllData();
+        expect(all['IABTCF_TCString'], 'CPXx');
+        expect(all['_ax_token'], 'tok');
+      });
+    });
+
+    group('getVendorConsents', () {
+      test('returns empty map when not set', () {
+        expect(storage.getVendorConsents(), isEmpty);
+      });
+
+      test('decodes bitstring correctly', () async {
+        SharedPreferences.setMockInitialValues(
+            {'IABTCF_VendorConsents': '101'});
+        final prefs = await SharedPreferences.getInstance();
+        final s = TcfStorage(prefs);
+        final consents = s.getVendorConsents();
+        expect(consents[1], isTrue);
+        expect(consents[2], isFalse);
+        expect(consents[3], isTrue);
+      });
+
+      test('all consented', () async {
+        SharedPreferences.setMockInitialValues(
+            {'IABTCF_VendorConsents': '111'});
+        final prefs = await SharedPreferences.getInstance();
+        final s = TcfStorage(prefs);
+        final consents = s.getVendorConsents();
+        expect(consents[1], isTrue);
+        expect(consents[2], isTrue);
+        expect(consents[3], isTrue);
+      });
+
+      test('all refused', () async {
+        SharedPreferences.setMockInitialValues(
+            {'IABTCF_VendorConsents': '000'});
+        final prefs = await SharedPreferences.getInstance();
+        final s = TcfStorage(prefs);
+        final consents = s.getVendorConsents();
+        expect(consents[1], isFalse);
+        expect(consents[2], isFalse);
+        expect(consents[3], isFalse);
+      });
+    });
+  });
+}

--- a/test/webview/webview_axeptio_sdk_test.dart
+++ b/test/webview/webview_axeptio_sdk_test.dart
@@ -11,12 +11,21 @@ import 'package:webview_flutter_platform_interface/webview_flutter_platform_inte
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  WebViewPlatform? savedWebViewPlatform;
+
   group('WebViewAxeptioSdk', () {
     late WebViewAxeptioSdk sdk;
 
     setUp(() async {
+      savedWebViewPlatform = WebViewPlatform.instance;
       SharedPreferences.setMockInitialValues({});
       sdk = WebViewAxeptioSdk();
+    });
+
+    tearDown(() {
+      if (savedWebViewPlatform != null) {
+        WebViewPlatform.instance = savedWebViewPlatform!;
+      }
     });
 
     group('initialization', () {

--- a/test/webview/webview_axeptio_sdk_test.dart
+++ b/test/webview/webview_axeptio_sdk_test.dart
@@ -30,6 +30,12 @@ void main() {
 
       test('initialize stores configuration', () async {
         await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', 'tok');
+        expect(await sdk.axeptioToken, 'tok');
+      });
+
+      test('axeptioToken returns null when no init token and storage empty',
+          () async {
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
         expect(await sdk.axeptioToken, isNull);
       });
 
@@ -96,6 +102,31 @@ void main() {
         await tester.pumpAndSettle();
 
         expect(find.byType(AxeptioConsentView), findsOneWidget);
+
+        WebViewAxeptioSdk.navigatorKey = null;
+      });
+
+      testWidgets('consentUrl contains showConsentManager=true',
+          (tester) async {
+        WebViewPlatform.instance = _MockWebViewPlatform();
+        final navKey = GlobalKey<NavigatorState>();
+        WebViewAxeptioSdk.navigatorKey = navKey;
+
+        await sdk.initialize(
+            AxeptioService.publishers, 'client-id', 'version', null);
+
+        await tester.pumpWidget(MaterialApp(
+          navigatorKey: navKey,
+          home: const Scaffold(body: Text('home')),
+        ));
+        await tester.pumpAndSettle();
+
+        await sdk.showConsentScreen();
+        await tester.pumpAndSettle();
+
+        final view =
+            tester.widget<AxeptioConsentView>(find.byType(AxeptioConsentView));
+        expect(view.consentUrl.queryParameters['showConsentManager'], 'true');
 
         WebViewAxeptioSdk.navigatorKey = null;
       });

--- a/test/webview/webview_axeptio_sdk_test.dart
+++ b/test/webview/webview_axeptio_sdk_test.dart
@@ -12,9 +12,17 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   WebViewPlatform? savedWebViewPlatform;
+  WebViewPlatform? originalWebViewPlatform;
 
   setUpAll(() {
+    originalWebViewPlatform = WebViewPlatform.instance;
     WebViewPlatform.instance = _MockWebViewPlatform();
+  });
+
+  tearDownAll(() {
+    if (originalWebViewPlatform != null) {
+      WebViewPlatform.instance = originalWebViewPlatform!;
+    }
   });
 
   group('WebViewAxeptioSdk', () {

--- a/test/webview/webview_axeptio_sdk_test.dart
+++ b/test/webview/webview_axeptio_sdk_test.dart
@@ -1,0 +1,509 @@
+import 'package:axeptio_sdk/src/events/event_listener.dart';
+import 'package:axeptio_sdk/src/model/axeptio_service.dart';
+import 'package:axeptio_sdk/src/model/consents_v2.dart';
+import 'package:axeptio_sdk/src/webview/axeptio_consent_view.dart';
+import 'package:axeptio_sdk/src/webview/webview_axeptio_sdk.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('WebViewAxeptioSdk', () {
+    late WebViewAxeptioSdk sdk;
+
+    setUp(() async {
+      SharedPreferences.setMockInitialValues({});
+      sdk = WebViewAxeptioSdk();
+    });
+
+    group('initialization', () {
+      test('getPlatformVersion returns null', () async {
+        expect(await sdk.getPlatformVersion(), isNull);
+      });
+
+      test('axeptioToken returns null before initialize', () async {
+        expect(await sdk.axeptioToken, isNull);
+      });
+
+      test('initialize stores configuration', () async {
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', 'tok');
+        expect(await sdk.axeptioToken, isNull);
+      });
+
+      test('initialize creates storage', () async {
+        await sdk.initialize(AxeptioService.brands, 'cid', 'cv', null);
+        final data = await sdk.getConsentSavedData();
+        expect(data, isNull);
+      });
+    });
+
+    group('setupUI', () {
+      test('does nothing when storage is null (not initialized)', () async {
+        await expectLater(sdk.setupUI(), completes);
+      });
+
+      test('does nothing when tcString already exists', () async {
+        SharedPreferences.setMockInitialValues({'IABTCF_TCString': 'CPXxRfAP'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        // No navigator key set — if it would show screen it would silently skip
+        await expectLater(sdk.setupUI(), completes);
+      });
+    });
+
+    group('setUserDeniedTracking', () {
+      test('completes without error', () async {
+        await expectLater(sdk.setUserDeniedTracking(), completes);
+      });
+    });
+
+    group('showConsentScreen', () {
+      test('does nothing when navigatorKey is null', () async {
+        WebViewAxeptioSdk.navigatorKey = null;
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        await expectLater(sdk.showConsentScreen(), completes);
+      });
+
+      test('does nothing when navigator state is null', () async {
+        WebViewAxeptioSdk.navigatorKey = GlobalKey<NavigatorState>();
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        await expectLater(sdk.showConsentScreen(), completes);
+      });
+
+      test('does nothing when not initialized', () async {
+        WebViewAxeptioSdk.navigatorKey = null;
+        await expectLater(sdk.showConsentScreen(), completes);
+      });
+
+      testWidgets('pushes AxeptioConsentView with valid navigator',
+          (tester) async {
+        WebViewPlatform.instance = _MockWebViewPlatform();
+        final navKey = GlobalKey<NavigatorState>();
+        WebViewAxeptioSdk.navigatorKey = navKey;
+
+        await sdk.initialize(
+            AxeptioService.publishers, 'client-id', 'version', null);
+
+        await tester.pumpWidget(MaterialApp(
+          navigatorKey: navKey,
+          home: const Scaffold(body: Text('home')),
+        ));
+        await tester.pumpAndSettle();
+
+        await sdk.showConsentScreen();
+        await tester.pumpAndSettle();
+
+        expect(find.byType(AxeptioConsentView), findsOneWidget);
+
+        WebViewAxeptioSdk.navigatorKey = null;
+      });
+    });
+
+    group('setupUI calls showConsentScreen', () {
+      testWidgets('setupUI shows consent when tcString is empty',
+          (tester) async {
+        WebViewPlatform.instance = _MockWebViewPlatform();
+        final navKey = GlobalKey<NavigatorState>();
+        WebViewAxeptioSdk.navigatorKey = navKey;
+
+        SharedPreferences.setMockInitialValues({});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+
+        await tester.pumpWidget(MaterialApp(
+          navigatorKey: navKey,
+          home: const Scaffold(body: Text('home')),
+        ));
+        await tester.pumpAndSettle();
+
+        await sdk.setupUI();
+        await tester.pumpAndSettle();
+
+        expect(find.byType(AxeptioConsentView), findsOneWidget);
+
+        WebViewAxeptioSdk.navigatorKey = null;
+      });
+    });
+
+    group('clearConsent', () {
+      test('completes when storage is null', () async {
+        await expectLater(sdk.clearConsent(), completes);
+      });
+
+      test('notifies listeners via onConsentCleared', () async {
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        bool cleared = false;
+        final listener = AxeptioEventListener();
+        listener.onConsentCleared = () => cleared = true;
+        sdk.addEventListener(listener);
+
+        await sdk.clearConsent();
+
+        expect(cleared, isTrue);
+      });
+
+      test('clears stored data', () async {
+        SharedPreferences.setMockInitialValues(
+            {'IABTCF_TCString': 'CPXx', '_ax_token': 'tok'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+
+        await sdk.clearConsent();
+
+        expect(await sdk.axeptioToken, isNull);
+        expect(await sdk.getConsentSavedData(), isNull);
+      });
+    });
+
+    group('getConsentSavedData', () {
+      test('returns null when not initialized', () async {
+        expect(await sdk.getConsentSavedData(), isNull);
+      });
+
+      test('returns null when no data stored', () async {
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        expect(await sdk.getConsentSavedData(), isNull);
+      });
+
+      test('returns all data', () async {
+        SharedPreferences.setMockInitialValues({'IABTCF_TCString': 'CPXx'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        final data = await sdk.getConsentSavedData();
+        expect(data, isNotNull);
+        expect(data!['IABTCF_TCString'], 'CPXx');
+      });
+
+      test('returns specific key data', () async {
+        SharedPreferences.setMockInitialValues(
+            {'IABTCF_TCString': 'CPXx', '_ax_token': 'tok'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        final data =
+            await sdk.getConsentSavedData(preferenceKey: 'IABTCF_TCString');
+        expect(data, {'IABTCF_TCString': 'CPXx'});
+      });
+
+      test('returns null for non-existent key', () async {
+        SharedPreferences.setMockInitialValues({'IABTCF_TCString': 'CPXx'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        final data =
+            await sdk.getConsentSavedData(preferenceKey: 'non_existent');
+        expect(data, isNull);
+      });
+    });
+
+    group('getConsentDebugInfo', () {
+      test('delegates to getConsentSavedData', () async {
+        SharedPreferences.setMockInitialValues({'IABTCF_TCString': 'CPXx'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        final debug = await sdk.getConsentDebugInfo();
+        final saved = await sdk.getConsentSavedData();
+        expect(debug, equals(saved));
+      });
+    });
+
+    group('getVendorConsents', () {
+      test('returns empty map when not initialized', () async {
+        expect(await sdk.getVendorConsents(), isEmpty);
+      });
+
+      test('returns decoded vendor consents', () async {
+        SharedPreferences.setMockInitialValues(
+            {'IABTCF_VendorConsents': '101'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        final consents = await sdk.getVendorConsents();
+        expect(consents[1], isTrue);
+        expect(consents[2], isFalse);
+        expect(consents[3], isTrue);
+      });
+    });
+
+    group('getConsentedVendors', () {
+      test('returns empty list when not initialized', () async {
+        expect(await sdk.getConsentedVendors(), isEmpty);
+      });
+
+      test('returns consented vendor IDs', () async {
+        SharedPreferences.setMockInitialValues(
+            {'IABTCF_VendorConsents': '101'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        final vendors = await sdk.getConsentedVendors();
+        expect(vendors, containsAll([1, 3]));
+        expect(vendors, isNot(contains(2)));
+      });
+    });
+
+    group('getRefusedVendors', () {
+      test('returns empty list when not initialized', () async {
+        expect(await sdk.getRefusedVendors(), isEmpty);
+      });
+
+      test('returns refused vendor IDs', () async {
+        SharedPreferences.setMockInitialValues(
+            {'IABTCF_VendorConsents': '101'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        final vendors = await sdk.getRefusedVendors();
+        expect(vendors, contains(2));
+        expect(vendors, isNot(contains(1)));
+      });
+    });
+
+    group('isVendorConsented', () {
+      test('returns false when not initialized', () async {
+        expect(await sdk.isVendorConsented(1), isFalse);
+      });
+
+      test('returns true for consented vendor', () async {
+        SharedPreferences.setMockInitialValues(
+            {'IABTCF_VendorConsents': '101'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        expect(await sdk.isVendorConsented(1), isTrue);
+      });
+
+      test('returns false for refused vendor', () async {
+        SharedPreferences.setMockInitialValues(
+            {'IABTCF_VendorConsents': '101'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        expect(await sdk.isVendorConsented(2), isFalse);
+      });
+
+      test('returns false for out-of-range vendor', () async {
+        SharedPreferences.setMockInitialValues(
+            {'IABTCF_VendorConsents': '101'});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+        expect(await sdk.isVendorConsented(999), isFalse);
+      });
+    });
+
+    group('appendAxeptioTokenURL', () {
+      test('returns original url when not initialized', () async {
+        final result =
+            await sdk.appendAxeptioTokenURL('https://example.com', 'tok');
+        expect(result, 'https://example.com');
+      });
+
+      test('appends params when initialized', () async {
+        await sdk.initialize(
+            AxeptioService.publishers, 'my-cid', 'my-cv', null);
+        final result =
+            await sdk.appendAxeptioTokenURL('https://example.com', 'tok');
+        expect(result, isNotNull);
+        final uri = Uri.parse(result!);
+        expect(uri.queryParameters['clientId'], 'my-cid');
+        expect(uri.queryParameters['cookiesVersion'], 'my-cv');
+        expect(uri.queryParameters['axeptio_token'], 'tok');
+      });
+    });
+
+    group('event listeners', () {
+      test('addEventListener and removeEventListener work', () {
+        final listener = AxeptioEventListener();
+        expect(() => sdk.addEventListener(listener), returnsNormally);
+        expect(() => sdk.removeEventListener(listener), returnsNormally);
+      });
+
+      test('listeners receive onPopupClosedEvent from JS cookies:close',
+          () async {
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+
+        bool closed = false;
+        final listener = AxeptioEventListener();
+        listener.onPopupClosedEvent = () => closed = true;
+        sdk.addEventListener(listener);
+
+        sdk.handleJsEvent('cookies:close', null);
+
+        expect(closed, isTrue);
+      });
+
+      test('listeners receive onGoogleConsentModeUpdate', () async {
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+
+        ConsentsV2? received;
+        final listener = AxeptioEventListener();
+        listener.onGoogleConsentModeUpdate = (c) => received = c;
+        sdk.addEventListener(listener);
+
+        sdk.handleJsEvent('google:consent-mode-v2-update', {
+          'analytics_storage': true,
+          'ad_storage': false,
+          'ad_user_data': true,
+          'ad_personalization': false,
+        });
+
+        expect(received, isNotNull);
+        expect(received!.analyticsStorage, isTrue);
+        expect(received!.adStorage, isFalse);
+        expect(received!.adUserData, isTrue);
+        expect(received!.adPersonalization, isFalse);
+      });
+
+      test('iabtcf event writes to storage', () async {
+        SharedPreferences.setMockInitialValues({});
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+
+        sdk.handleJsEvent('iabtcf', {'IABTCF_TCString': 'CPXxTest'});
+
+        final data = await sdk.getConsentSavedData();
+        expect(data?['IABTCF_TCString'], 'CPXxTest');
+      });
+
+      test('consent:saved event writes token', () async {
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+
+        sdk.handleJsEvent('consent:saved', {'axeptio_token': 'new-token'});
+
+        expect(await sdk.axeptioToken, 'new-token');
+      });
+
+      test('axeptio:cookies event writes cookies', () async {
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+
+        sdk.handleJsEvent('axeptio:cookies', {'axeptio_cookies': '{"a":1}'});
+
+        final data = await sdk.getConsentSavedData();
+        expect(data?['axeptio_cookies'], '{"a":1}');
+      });
+
+      test('cookies:complete event writes scope', () async {
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+
+        sdk.handleJsEvent('cookies:complete', {'scope': 'persistent'});
+
+        final data = await sdk.getConsentSavedData();
+        expect(data?['widget_scope'], 'persistent');
+      });
+
+      test('unknown events are silently ignored', () async {
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+
+        expect(() => sdk.handleJsEvent('unknown:event', null), returnsNormally);
+      });
+
+      test('google consent with null payload is ignored', () async {
+        await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
+
+        ConsentsV2? received;
+        final listener = AxeptioEventListener();
+        listener.onGoogleConsentModeUpdate = (c) => received = c;
+        sdk.addEventListener(listener);
+
+        sdk.handleJsEvent('google:consent-mode-v2-update', null);
+
+        expect(received, isNull);
+      });
+    });
+  });
+}
+
+class _MockWebViewPlatform extends WebViewPlatform {
+  @override
+  PlatformWebViewController createPlatformWebViewController(
+          PlatformWebViewControllerCreationParams params) =>
+      _MockCtrl(params);
+
+  @override
+  PlatformWebViewWidget createPlatformWebViewWidget(
+          PlatformWebViewWidgetCreationParams params) =>
+      _MockWidget(params);
+
+  @override
+  PlatformWebViewCookieManager createPlatformCookieManager(
+          PlatformWebViewCookieManagerCreationParams params) =>
+      _MockCookies(params);
+
+  @override
+  PlatformNavigationDelegate createPlatformNavigationDelegate(
+          PlatformNavigationDelegateCreationParams params) =>
+      _MockDelegate(params);
+}
+
+class _MockCtrl extends PlatformWebViewController {
+  _MockCtrl(super.p) : super.implementation();
+  @override
+  Future<void> setJavaScriptMode(JavaScriptMode m) async {}
+  @override
+  Future<void> setBackgroundColor(Color c) async {}
+  @override
+  Future<void> setPlatformNavigationDelegate(
+      PlatformNavigationDelegate h) async {}
+  @override
+  Future<void> addJavaScriptChannel(JavaScriptChannelParams p) async {}
+  @override
+  Future<void> removeJavaScriptChannel(String n) async {}
+  @override
+  Future<void> loadRequest(LoadRequestParams p) async {}
+  @override
+  Future<void> loadHtmlString(String h, {String? baseUrl}) async {}
+  @override
+  Future<void> loadFile(String p) async {}
+  @override
+  Future<void> loadFlutterAsset(String k) async {}
+  @override
+  Future<String?> currentUrl() async => null;
+  @override
+  Future<bool> canGoBack() async => false;
+  @override
+  Future<bool> canGoForward() async => false;
+  @override
+  Future<void> goBack() async {}
+  @override
+  Future<void> goForward() async {}
+  @override
+  Future<void> reload() async {}
+  @override
+  Future<void> clearCache() async {}
+  @override
+  Future<void> clearLocalStorage() async {}
+  @override
+  Future<void> runJavaScript(String js) async {}
+  @override
+  Future<Object> runJavaScriptReturningResult(String js) async => '';
+  @override
+  Future<String?> getTitle() async => null;
+  @override
+  Future<void> scrollTo(int x, int y) async {}
+  @override
+  Future<void> scrollBy(int x, int y) async {}
+  @override
+  Future<Offset> getScrollPosition() async => Offset.zero;
+  @override
+  Future<void> enableZoom(bool e) async {}
+  Future<void> setCustomUserAgent(String? ua) async {}
+  @override
+  Future<String?> getUserAgent() async => null;
+}
+
+class _MockWidget extends PlatformWebViewWidget {
+  _MockWidget(super.p) : super.implementation();
+  @override
+  Widget build(BuildContext ctx) => const SizedBox.shrink();
+}
+
+class _MockCookies extends PlatformWebViewCookieManager {
+  _MockCookies(super.p) : super.implementation();
+  @override
+  Future<bool> clearCookies() async => true;
+  @override
+  Future<void> setCookie(WebViewCookie c) async {}
+}
+
+class _MockDelegate extends PlatformNavigationDelegate {
+  _MockDelegate(super.p) : super.implementation();
+  @override
+  Future<void> setOnNavigationRequest(NavigationRequestCallback f) async {}
+  @override
+  Future<void> setOnPageStarted(PageEventCallback f) async {}
+  @override
+  Future<void> setOnPageFinished(PageEventCallback f) async {}
+  @override
+  Future<void> setOnProgress(ProgressCallback f) async {}
+  @override
+  Future<void> setOnWebResourceError(WebResourceErrorCallback f) async {}
+  @override
+  Future<void> setOnUrlChange(UrlChangeCallback f) async {}
+  @override
+  Future<void> setOnHttpAuthRequest(HttpAuthRequestCallback f) async {}
+  @override
+  Future<void> setOnHttpError(HttpResponseErrorCallback f) async {}
+}

--- a/test/webview/webview_axeptio_sdk_test.dart
+++ b/test/webview/webview_axeptio_sdk_test.dart
@@ -13,6 +13,10 @@ void main() {
 
   WebViewPlatform? savedWebViewPlatform;
 
+  setUpAll(() {
+    WebViewPlatform.instance = _MockWebViewPlatform();
+  });
+
   group('WebViewAxeptioSdk', () {
     late WebViewAxeptioSdk sdk;
 
@@ -23,9 +27,7 @@ void main() {
     });
 
     tearDown(() {
-      if (savedWebViewPlatform != null) {
-        WebViewPlatform.instance = savedWebViewPlatform!;
-      }
+      WebViewPlatform.instance = savedWebViewPlatform!;
     });
 
     group('initialization', () {

--- a/test/webview/webview_axeptio_sdk_test.dart
+++ b/test/webview/webview_axeptio_sdk_test.dart
@@ -6,7 +6,6 @@ import 'package:axeptio_sdk/src/webview/webview_axeptio_sdk.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import 'package:webview_flutter/webview_flutter.dart';
 import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
 
 void main() {
@@ -146,7 +145,7 @@ void main() {
 
       test('clears stored data', () async {
         SharedPreferences.setMockInitialValues(
-            {'IABTCF_TCString': 'CPXx', '_ax_token': 'tok'});
+            {'IABTCF_TCString': 'CPXx', 'AX_CLIENT_TOKEN': 'tok'});
         await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
 
         await sdk.clearConsent();
@@ -311,7 +310,7 @@ void main() {
         listener.onPopupClosedEvent = () => closed = true;
         sdk.addEventListener(listener);
 
-        sdk.handleJsEvent('cookies:close', null);
+        await sdk.handleJsEvent('cookies:close', null);
 
         expect(closed, isTrue);
       });
@@ -324,7 +323,7 @@ void main() {
         listener.onGoogleConsentModeUpdate = (c) => received = c;
         sdk.addEventListener(listener);
 
-        sdk.handleJsEvent('google:consent-mode-v2-update', {
+        await sdk.handleJsEvent('google:consent-mode-v2-update', {
           'analytics_storage': true,
           'ad_storage': false,
           'ad_user_data': true,
@@ -342,7 +341,7 @@ void main() {
         SharedPreferences.setMockInitialValues({});
         await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
 
-        sdk.handleJsEvent('iabtcf', {'IABTCF_TCString': 'CPXxTest'});
+        await sdk.handleJsEvent('iabtcf', {'IABTCF_TCString': 'CPXxTest'});
 
         final data = await sdk.getConsentSavedData();
         expect(data?['IABTCF_TCString'], 'CPXxTest');
@@ -351,7 +350,8 @@ void main() {
       test('consent:saved event writes token', () async {
         await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
 
-        sdk.handleJsEvent('consent:saved', {'axeptio_token': 'new-token'});
+        await sdk
+            .handleJsEvent('consent:saved', {'axeptio_token': 'new-token'});
 
         expect(await sdk.axeptioToken, 'new-token');
       });
@@ -359,7 +359,8 @@ void main() {
       test('axeptio:cookies event writes cookies', () async {
         await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
 
-        sdk.handleJsEvent('axeptio:cookies', {'axeptio_cookies': '{"a":1}'});
+        await sdk
+            .handleJsEvent('axeptio:cookies', {'axeptio_cookies': '{"a":1}'});
 
         final data = await sdk.getConsentSavedData();
         expect(data?['axeptio_cookies'], '{"a":1}');
@@ -368,7 +369,7 @@ void main() {
       test('cookies:complete event writes scope', () async {
         await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
 
-        sdk.handleJsEvent('cookies:complete', {'scope': 'persistent'});
+        await sdk.handleJsEvent('cookies:complete', {'scope': 'persistent'});
 
         final data = await sdk.getConsentSavedData();
         expect(data?['widget_scope'], 'persistent');
@@ -377,7 +378,7 @@ void main() {
       test('unknown events are silently ignored', () async {
         await sdk.initialize(AxeptioService.publishers, 'cid', 'cv', null);
 
-        expect(() => sdk.handleJsEvent('unknown:event', null), returnsNormally);
+        await expectLater(sdk.handleJsEvent('unknown:event', null), completes);
       });
 
       test('google consent with null payload is ignored', () async {
@@ -388,7 +389,7 @@ void main() {
         listener.onGoogleConsentModeUpdate = (c) => received = c;
         sdk.addEventListener(listener);
 
-        sdk.handleJsEvent('google:consent-mode-v2-update', null);
+        await sdk.handleJsEvent('google:consent-mode-v2-update', null);
 
         expect(received, isNull);
       });

--- a/test/webview/webview_axeptio_sdk_test.dart
+++ b/test/webview/webview_axeptio_sdk_test.dart
@@ -153,6 +153,18 @@ void main() {
         expect(await sdk.axeptioToken, isNull);
         expect(await sdk.getConsentSavedData(), isNull);
       });
+
+      test('resets in-memory token after clearConsent', () async {
+        await sdk.initialize(
+            AxeptioService.publishers, 'cid', 'cv', 'initial-tok');
+        await sdk
+            .handleJsEvent('consent:saved', {'axeptio_token': 'updated-tok'});
+        expect(await sdk.axeptioToken, 'updated-tok');
+
+        await sdk.clearConsent();
+
+        expect(await sdk.axeptioToken, isNull);
+      });
     });
 
     group('getConsentSavedData', () {
@@ -354,6 +366,18 @@ void main() {
             .handleJsEvent('consent:saved', {'axeptio_token': 'new-token'});
 
         expect(await sdk.axeptioToken, 'new-token');
+      });
+
+      test(
+          'showConsentScreen uses updated token from storage after consent:saved',
+          () async {
+        await sdk.initialize(
+            AxeptioService.publishers, 'cid', 'cv', 'initial-tok');
+        await sdk
+            .handleJsEvent('consent:saved', {'axeptio_token': 'refreshed-tok'});
+        // The storage now holds 'refreshed-tok'; _token still holds 'initial-tok'.
+        // Verify that axeptioToken (sourced from storage) reflects the update.
+        expect(await sdk.axeptioToken, 'refreshed-tok');
       });
 
       test('axeptio:cookies event writes cookies', () async {

--- a/test/webview/webview_axeptio_sdk_test.dart
+++ b/test/webview/webview_axeptio_sdk_test.dart
@@ -420,7 +420,7 @@ class _MockWebViewPlatform extends WebViewPlatform {
 }
 
 class _MockCtrl extends PlatformWebViewController {
-  _MockCtrl(super.p) : super.implementation();
+  _MockCtrl(super.params) : super.implementation();
   @override
   Future<void> setJavaScriptMode(JavaScriptMode m) async {}
   @override
@@ -476,13 +476,13 @@ class _MockCtrl extends PlatformWebViewController {
 }
 
 class _MockWidget extends PlatformWebViewWidget {
-  _MockWidget(super.p) : super.implementation();
+  _MockWidget(super.params) : super.implementation();
   @override
   Widget build(BuildContext ctx) => const SizedBox.shrink();
 }
 
 class _MockCookies extends PlatformWebViewCookieManager {
-  _MockCookies(super.p) : super.implementation();
+  _MockCookies(super.params) : super.implementation();
   @override
   Future<bool> clearCookies() async => true;
   @override
@@ -490,7 +490,7 @@ class _MockCookies extends PlatformWebViewCookieManager {
 }
 
 class _MockDelegate extends PlatformNavigationDelegate {
-  _MockDelegate(super.p) : super.implementation();
+  _MockDelegate(super.params) : super.implementation();
   @override
   Future<void> setOnNavigationRequest(NavigationRequestCallback f) async {}
   @override


### PR DESCRIPTION
## Summary

- Replaces native iOS (AxeptioIOSSDK) and Android SDK channel implementation with a pure Flutter WebView approach, loading the Axeptio web consent form directly
- Eliminates native SDK dependencies, Gradle GitHub auth config, and CocoaPods setup complexity for app developers
- Public API is 100% identical — no Dart-side changes required for existing consumers (except adding `navigatorKey`)

## New Files

- `lib/src/webview/consent_url_builder.dart` — pure Dart URL builder for consent form
- `lib/src/webview/tcf_storage.dart` — SharedPreferences wrapper for all IABTCF_* and Axeptio keys
- `lib/src/webview/axeptio_consent_view.dart` — WebView widget with JS polyfill injection and message routing
- `lib/src/webview/webview_axeptio_sdk.dart` — full `AxeptioSdkPlatform` implementation

## Modified Files

- `lib/src/channel/axeptio_sdk_platform_interface.dart` — switched default instance to `WebViewAxeptioSdk`
- `lib/src/channel/axeptio.dart` — added `navigatorKey` static getter/setter
- `lib/src/events/events_handler.dart` — accepts `Stream<dynamic>` in constructor for testability
- `lib/src/src.dart` — added webview exports
- `pubspec.yaml` — added `webview_flutter: ^4.10.0`

## Migration (v2 → v3)

App developers must add one setup step:
```dart
AxeptioSdk.navigatorKey = GlobalKey<NavigatorState>();
// and pass it to MaterialApp:
MaterialApp(navigatorKey: AxeptioSdk.navigatorKey, ...)
```

They can remove:
- Gradle GitHub packages auth configuration
- CocoaPods `AxeptioIOSSDK` pod configuration

## Test Plan

- [x] 299 tests passing
- [x] 97.7% coverage (≥ 95% requirement)
- [x] `flutter analyze` — zero warnings
- [x] `dart format` — no changes needed
- [ ] Manual verification on iOS device: consent form loads, accept/refuse fires listener events, `IABTCF_TCString` written to SharedPreferences
- [ ] Manual verification on Android device: same as above
- [ ] `clearConsent()` removes all keys
- [ ] `appendAxeptioTokenURL()` returns URL with correct params
- [ ] `onGoogleConsentModeUpdate` fires with correct `ConsentsV2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the native iOS/Android SDKs with a pure Flutter WebView (`webview_flutter`) while keeping the Dart API intact and requiring a `navigatorKey`. Aligns with Linear MSK-90 and deprecates the native method-channel plugins in favor of the WebView implementation.

- **Bug Fixes**
  - Tests: save the original `WebViewPlatform.instance` in `setUpAll` and restore it in `tearDownAll` to prevent cross-test contamination.
  - URL handling: use `Uri.tryParse` in `appendToken`; fall back to the original URL on invalid input.
  - Token/storage: clear legacy `_ax_token` when writing `AX_CLIENT_TOKEN`; build `clearAll()`/`getAllData()` keys from `NativeDefaultPreferences.allKeys` to include all supported keys.
  - WebView hardening: https-only allowlist to `static.axept.io`; `showConsentScreen` passes `showConsentManager=true`; 190-day cookie window constant; debug logging for JS parse errors.

- **Migration**
  - Add a global navigator key and pass it to your app.
  - Remove native setup (Gradle GitHub auth and CocoaPods `AxeptioIOSSDK`).
  - Dependencies: add `webview_flutter: ^4.10.0` and dev `webview_flutter_platform_interface`.
  - Notes: method-channel `AxeptioSdk` is deprecated; native plugins are stubs and most method calls will throw; token key is now `AX_CLIENT_TOKEN` and legacy `_ax_token` is cleaned up during migration.

<sup>Written for commit 7a1774ed4f9a4ac90b7f2bffb5ffbc5c56ac7c68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

