### PR TITLE
fix(core): use transparent route for consent webview overlay

### DIFF
--- a/lib/src/webview/webview_axeptio_sdk.dart
+++ b/lib/src/webview/webview_axeptio_sdk.dart
@@ -82,8 +82,9 @@ class WebViewAxeptioSdk extends AxeptioSdkPlatform {
     );
 
     await key.currentState!.push(
-      MaterialPageRoute(
-        builder: (_) => AxeptioConsentView(
+      PageRouteBuilder(
+        opaque: false,
+        pageBuilder: (_, __, ___) => AxeptioConsentView(
           consentUrl: url,
           attDenied: _attDenied,
           storedTcString: _storage?.tcString,
@@ -92,7 +93,6 @@ class WebViewAxeptioSdk extends AxeptioSdkPlatform {
           onClose: () => key.currentState?.pop(),
           onError: (error) => _eventsHandler.handleDAxeptioErrorEvent(error),
         ),
-        fullscreenDialog: true,
       ),
     );
   }

--- a/lib/src/webview/webview_axeptio_sdk.dart
+++ b/lib/src/webview/webview_axeptio_sdk.dart
@@ -84,6 +84,8 @@ class WebViewAxeptioSdk extends AxeptioSdkPlatform {
     await key.currentState!.push(
       PageRouteBuilder(
         opaque: false,
+        barrierColor: Colors.transparent,
+        barrierDismissible: false,
         pageBuilder: (_, __, ___) => AxeptioConsentView(
           consentUrl: url,
           attDenied: _attDenied,


### PR DESCRIPTION
## Summary
- Replace `MaterialPageRoute` (opaque) with `PageRouteBuilder(opaque: false)` for the consent webview route
- The consent widget is an overlay — the app should be visible behind it, not a black background

## Changes
- **`lib/src/webview/webview_axeptio_sdk.dart`** — Switch from `MaterialPageRoute` to `PageRouteBuilder` with `opaque: false`

## Test plan
- [x] `flutter test` — 349 tests pass
- [x] Manual test on iOS simulator: consent overlay shows with app visible behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)