### PR TITLE
feat(android): add consent webview support for Android

### DIFF
--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -24,7 +24,7 @@ if (flutterVersionName == null) {
 
 android {
     namespace "io.axept.axeptio_sdk_example"
-    compileSdk 35
+    compileSdk 36
     ndkVersion = flutter.ndkVersion
 
     compileOptions {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -81,6 +81,7 @@ class MyApp extends StatefulWidget {
 class _MyAppState extends State<MyApp> {
   InterstitialAd? _interstitialAd;
   Function()? _onAdBtnPressed;
+  bool _adsInitialized = false;
 
   final _axeptioSdkPlugin = AxeptioSdk();
 
@@ -91,6 +92,7 @@ class _MyAppState extends State<MyApp> {
 
   /// Loads an interstitial ad.
   void loadAd() {
+    if (!_adsInitialized) return;
     InterstitialAd.load(
       adUnitId: adUnitId,
       request: const AdRequest(),
@@ -127,6 +129,7 @@ class _MyAppState extends State<MyApp> {
   Future<void> _initAll() async {
     await initSDK();
     await MobileAds.instance.initialize();
+    _adsInitialized = true;
     loadAd();
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,7 +18,6 @@ import 'package:google_mobile_ads/google_mobile_ads.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
-  MobileAds.instance.initialize();
   AxeptioSdk.navigatorKey = GlobalKey<NavigatorState>();
 
   runApp(const MyApp());
@@ -122,7 +121,12 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
-    initSDK();
+    _initAll();
+  }
+
+  Future<void> _initAll() async {
+    await initSDK();
+    await MobileAds.instance.initialize();
     loadAd();
   }
 

--- a/lib/src/webview/axeptio_consent_view.dart
+++ b/lib/src/webview/axeptio_consent_view.dart
@@ -66,9 +66,19 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
             'Consent webview is not supported on web',
           ),
         );
+        widget.onClose();
       });
     } else if (defaultTargetPlatform == TargetPlatform.android) {
       _initAndroidWebView();
+    } else if (defaultTargetPlatform != TargetPlatform.iOS) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        widget.onError?.call(
+          AxeptioWebViewException(
+            'Consent webview is not supported on ${defaultTargetPlatform.name}',
+          ),
+        );
+        widget.onClose();
+      });
     }
   }
 
@@ -81,7 +91,10 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
         onMessageReceived: _onAndroidJsMessage,
       )
       ..setNavigationDelegate(NavigationDelegate(
-        onPageStarted: (_) => _androidInjectScripts(),
+        onPageStarted: (_) {
+          _androidInjected = false;
+          _androidInjectScripts();
+        },
         onPageFinished: (_) => _androidInjectScripts(),
         onNavigationRequest: (request) {
           final uri = Uri.tryParse(request.url);
@@ -120,14 +133,18 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
     if (_androidInjected) return;
     final controller = _androidController;
     if (controller == null) return;
+    bool localStorageOk = false;
     try {
       await _androidInjectLocalStorage(controller);
+      localStorageOk = true;
     } on Exception {
       // May fail at onPageStarted; onPageFinished will retry.
     }
     try {
       await controller.runJavaScript(_androidPolyfillScript);
-      _androidInjected = true;
+      if (localStorageOk) {
+        _androidInjected = true;
+      }
     } on Exception catch (e) {
       widget.onError?.call(
         AxeptioWebViewException('Failed to inject polyfill: $e', cause: e),

--- a/lib/src/webview/axeptio_consent_view.dart
+++ b/lib/src/webview/axeptio_consent_view.dart
@@ -4,9 +4,23 @@ import 'package:axeptio_sdk/src/exceptions/axeptio_exceptions.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:webview_flutter/webview_flutter.dart';
 
 /// Duration in days for the Axeptio user cookie consent window.
 const int _axUserCookiesDurationDays = 190;
+
+/// Polyfill bridging the Axeptio web page's `window.axeptioAppSdk.onEvent()`
+/// to the Flutter JS channel on Android (via `addJavaScriptChannel`).
+const String _androidPolyfillScript = r'''
+window.axeptioAppSdk = window.axeptioAppSdk || {};
+if (typeof window.axeptioAppSdk.onEvent !== 'function') {
+  window.axeptioAppSdk.onEvent = function(event, payload) {
+    if (window.axeptioSdk) {
+      window.axeptioSdk.postMessage(JSON.stringify({ name: event, payload: payload }));
+    }
+  };
+}
+''';
 
 class AxeptioConsentView extends StatefulWidget {
   final Uri consentUrl;
@@ -35,21 +49,116 @@ class AxeptioConsentView extends StatefulWidget {
 /// Public state class to allow testing of message handling logic.
 @visibleForTesting
 class AxeptioConsentViewState extends State<AxeptioConsentView> {
+  // iOS: native PlatformView channel
   MethodChannel? _channel;
+
+  // Android: webview_flutter controller
+  WebViewController? _androidController;
+  bool _androidInjected = false;
 
   @override
   void initState() {
     super.initState();
-    if (kIsWeb || defaultTargetPlatform != TargetPlatform.iOS) {
+    if (kIsWeb) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         widget.onError?.call(
           const AxeptioWebViewException(
-            'Consent webview is only supported on iOS',
+            'Consent webview is not supported on web',
           ),
         );
       });
+    } else if (defaultTargetPlatform == TargetPlatform.android) {
+      _initAndroidWebView();
     }
   }
+
+  void _initAndroidWebView() {
+    _androidController = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..addJavaScriptChannel(
+        'axeptioSdk',
+        onMessageReceived: _onAndroidJsMessage,
+      )
+      ..setNavigationDelegate(NavigationDelegate(
+        onPageStarted: (_) => _androidInjectScripts(),
+        onPageFinished: (_) => _androidInjectScripts(),
+        onNavigationRequest: (request) {
+          final uri = Uri.tryParse(request.url);
+          if (uri?.scheme == 'https' && uri?.host == 'static.axept.io') {
+            return NavigationDecision.navigate;
+          }
+          return NavigationDecision.prevent;
+        },
+        onWebResourceError: (error) {
+          if (error.isForMainFrame ?? false) {
+            widget.onError?.call(
+              AxeptioNetworkException(
+                'WebView failed to load: ${error.description}',
+                cause: error,
+              ),
+            );
+          }
+        },
+        onHttpError: (error) {
+          final statusCode = error.response?.statusCode;
+          if (statusCode != null && statusCode >= 400) {
+            widget.onError?.call(
+              AxeptioNetworkException(
+                'WebView HTTP error: $statusCode',
+                statusCode: statusCode,
+                cause: error,
+              ),
+            );
+          }
+        },
+      ))
+      ..setBackgroundColor(Colors.transparent)
+      ..loadRequest(widget.consentUrl);
+  }
+
+  Future<void> _androidInjectScripts() async {
+    if (_androidInjected) return;
+    final controller = _androidController;
+    if (controller == null) return;
+    try {
+      await _androidInjectLocalStorage(controller);
+    } on Exception {
+      // May fail at onPageStarted; onPageFinished will retry.
+    }
+    try {
+      await controller.runJavaScript(_androidPolyfillScript);
+      _androidInjected = true;
+    } on Exception catch (e) {
+      widget.onError?.call(
+        AxeptioWebViewException('Failed to inject polyfill: $e', cause: e),
+      );
+    }
+  }
+
+  Future<void> _androidInjectLocalStorage(WebViewController controller) async {
+    final items = <String, String>{
+      '_ax_app_sdk_mode': 'true',
+      '_ax_user_cookies_duration': _axUserCookiesDurationDays.toString(),
+      if (widget.attDenied) '_ax_app_att_denied': 'true',
+      if (widget.storedTcString != null) '_ax_tcstring': widget.storedTcString!,
+    };
+    final script = items.entries
+        .map((e) =>
+            "localStorage.setItem(${jsonEncode(e.key)}, ${jsonEncode(e.value)});")
+        .join('\n');
+    await controller.runJavaScript(script);
+  }
+
+  void _onAndroidJsMessage(JavaScriptMessage message) {
+    try {
+      final decoded = jsonDecode(message.message) as Map<String, dynamic>;
+      final name = decoded['name'] as String?;
+      if (name == null) return;
+      _handleEvent(name, decoded['payload']);
+    } catch (_) {}
+  }
+
+  // iOS: native PlatformView callbacks
 
   void _onPlatformViewCreated(int viewId) {
     _channel = MethodChannel('axeptio/consent_webview_$viewId');
@@ -60,6 +169,7 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
   void dispose() {
     _channel?.setMethodCallHandler(null);
     _channel = null;
+    _androidController = null;
     super.dispose();
   }
 
@@ -91,9 +201,11 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
     }
   }
 
+  // Shared event handling
+
   void _handleEvent(String name, dynamic payloadRaw) {
-    // The native side may send payload as a JSON string or a structured
-    // Map/List, depending on how the JS bridge serializes the data.
+    // The native/JS side may send payload as a JSON string or a structured
+    // Map/List, depending on how the bridge serializes the data.
     Map<String, dynamic>? payload;
     if (payloadRaw is String && payloadRaw.isNotEmpty) {
       try {
@@ -125,10 +237,15 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
     }
     if (widget.showConsentManager) {
       try {
-        await _channel?.invokeMethod<void>(
-          'runJavaScript',
-          "window.axeptioSDK?.requestShow?.('consentManager')",
-        );
+        if (_androidController != null) {
+          await _androidController!.runJavaScript(
+              "window.axeptioSDK?.requestShow?.('consentManager')");
+        } else {
+          await _channel?.invokeMethod<void>(
+            'runJavaScript',
+            "window.axeptioSDK?.requestShow?.('consentManager')",
+          );
+        }
       } on PlatformException catch (e) {
         widget.onError?.call(
           AxeptioWebViewException('Failed to show consent manager: $e',
@@ -158,20 +275,26 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
   }
 
   Widget _buildWebView() {
-    if (kIsWeb || defaultTargetPlatform != TargetPlatform.iOS) {
+    if (kIsWeb) {
       return const Center(child: Text('Consent webview not available'));
     }
-    return UiKitView(
-      viewType: 'axeptio/consent_webview',
-      creationParams: <String, dynamic>{
-        'url': widget.consentUrl.toString(),
-        'attDenied': widget.attDenied,
-        'storedTcString': widget.storedTcString,
-        'showConsentManager': widget.showConsentManager,
-        'cookiesDurationDays': _axUserCookiesDurationDays,
-      },
-      creationParamsCodec: const StandardMessageCodec(),
-      onPlatformViewCreated: _onPlatformViewCreated,
-    );
+    if (defaultTargetPlatform == TargetPlatform.iOS) {
+      return UiKitView(
+        viewType: 'axeptio/consent_webview',
+        creationParams: <String, dynamic>{
+          'url': widget.consentUrl.toString(),
+          'attDenied': widget.attDenied,
+          'storedTcString': widget.storedTcString,
+          'showConsentManager': widget.showConsentManager,
+          'cookiesDurationDays': _axUserCookiesDurationDays,
+        },
+        creationParamsCodec: const StandardMessageCodec(),
+        onPlatformViewCreated: _onPlatformViewCreated,
+      );
+    }
+    if (_androidController != null) {
+      return WebViewWidget(controller: _androidController!);
+    }
+    return const Center(child: Text('Consent webview not available'));
   }
 }

--- a/lib/src/webview/axeptio_consent_view.dart
+++ b/lib/src/webview/axeptio_consent_view.dart
@@ -74,6 +74,7 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
 
   void _initAndroidWebView() {
     _androidController = WebViewController()
+      ..setBackgroundColor(Colors.transparent)
       ..setJavaScriptMode(JavaScriptMode.unrestricted)
       ..addJavaScriptChannel(
         'axeptioSdk',
@@ -84,9 +85,9 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
         onPageFinished: (_) => _androidInjectScripts(),
         onNavigationRequest: (request) {
           final uri = Uri.tryParse(request.url);
-          if (uri?.scheme == 'https' && uri?.host == 'static.axept.io') {
-            return NavigationDecision.navigate;
-          }
+          if (uri == null) return NavigationDecision.prevent;
+          if (uri.scheme == 'https') return NavigationDecision.navigate;
+          if (uri.scheme == 'about') return NavigationDecision.navigate;
           return NavigationDecision.prevent;
         },
         onWebResourceError: (error) {
@@ -112,7 +113,6 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
           }
         },
       ))
-      ..setBackgroundColor(Colors.transparent)
       ..loadRequest(widget.consentUrl);
   }
 

--- a/lib/src/webview/axeptio_consent_view.dart
+++ b/lib/src/webview/axeptio_consent_view.dart
@@ -99,7 +99,9 @@ class AxeptioConsentViewState extends State<AxeptioConsentView> {
         onNavigationRequest: (request) {
           final uri = Uri.tryParse(request.url);
           if (uri == null) return NavigationDecision.prevent;
-          if (uri.scheme == 'https') return NavigationDecision.navigate;
+          if (uri.scheme == 'https' && uri.host == widget.consentUrl.host) {
+            return NavigationDecision.navigate;
+          }
           if (uri.scheme == 'about') return NavigationDecision.navigate;
           return NavigationDecision.prevent;
         },

--- a/test/model/vendor_info_test.dart
+++ b/test/model/vendor_info_test.dart
@@ -471,6 +471,114 @@ void main() {
 
         expect(vendor1, isNot(equals(vendor2)));
       });
+
+      test('objects differing only in specialFeatures are not equal', () {
+        const vendor1 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          specialFeatures: [1],
+        );
+        const vendor2 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          specialFeatures: [2],
+        );
+        expect(vendor1, isNot(equals(vendor2)));
+      });
+
+      test('objects differing only in specialPurposes are not equal', () {
+        const vendor1 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          specialPurposes: [1],
+        );
+        const vendor2 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          specialPurposes: [2],
+        );
+        expect(vendor1, isNot(equals(vendor2)));
+      });
+
+      test('objects differing only in cookieMaxAgeSeconds are not equal', () {
+        const vendor1 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          cookieMaxAgeSeconds: 100,
+        );
+        const vendor2 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          cookieMaxAgeSeconds: 200,
+        );
+        expect(vendor1, isNot(equals(vendor2)));
+      });
+
+      test('objects differing only in usesCookies are not equal', () {
+        const vendor1 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          usesCookies: true,
+        );
+        const vendor2 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          usesCookies: false,
+        );
+        expect(vendor1, isNot(equals(vendor2)));
+      });
+
+      test('objects differing only in usesNonCookieAccess are not equal', () {
+        const vendor1 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          usesNonCookieAccess: true,
+        );
+        const vendor2 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          usesNonCookieAccess: false,
+        );
+        expect(vendor1, isNot(equals(vendor2)));
+      });
+
+      test('objects differing only in policyUrl are not equal', () {
+        const vendor1 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          policyUrl: 'https://a.com',
+        );
+        const vendor2 = VendorInfo(
+          id: 1,
+          name: 'V',
+          consented: true,
+          purposes: [1],
+          policyUrl: 'https://b.com',
+        );
+        expect(vendor1, isNot(equals(vendor2)));
+      });
     });
 
     group('toString method', () {

--- a/test/webview/axeptio_consent_view_test.dart
+++ b/test/webview/axeptio_consent_view_test.dart
@@ -8,16 +8,23 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
 
+WebViewPlatform? _previousWebViewPlatform;
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   final testUri = Uri.parse('https://static.axept.io/test.html');
 
   setUpAll(() {
+    _previousWebViewPlatform = WebViewPlatform.instance;
     // Provide a minimal WebView mock so Android code path doesn't crash.
-    // WebViewPlatform.instance is initially null in tests and the setter
-    // rejects null values, so we only set it once and don't restore.
     WebViewPlatform.instance = _CapturingWebViewPlatform();
+  });
+
+  tearDownAll(() {
+    if (_previousWebViewPlatform != null) {
+      WebViewPlatform.instance = _previousWebViewPlatform!;
+    }
   });
 
   group('AxeptioConsentView widget', () {
@@ -81,48 +88,50 @@ void main() {
     testWidgets('unsupported platform calls onError and onClose',
         (tester) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+      try {
+        final errors = <AxeptioException>[];
+        int closeCount = 0;
 
-      final errors = <AxeptioException>[];
-      int closeCount = 0;
+        await tester.pumpWidget(MaterialApp(
+          home: AxeptioConsentView(
+            consentUrl: testUri,
+            onJsEvent: (_, __) {},
+            onClose: () => closeCount++,
+            onError: (e) => errors.add(e),
+          ),
+        ));
+        await tester.pump(); // process post-frame callback
 
-      await tester.pumpWidget(MaterialApp(
-        home: AxeptioConsentView(
-          consentUrl: testUri,
-          onJsEvent: (_, __) {},
-          onClose: () => closeCount++,
-          onError: (e) => errors.add(e),
-        ),
-      ));
-      await tester.pump(); // process post-frame callback
-
-      debugDefaultTargetPlatformOverride = null;
-
-      expect(errors, hasLength(1));
-      expect(errors.first, isA<AxeptioWebViewException>());
-      expect(errors.first.message, contains('linux'));
-      expect(closeCount, 1);
+        expect(errors, hasLength(1));
+        expect(errors.first, isA<AxeptioWebViewException>());
+        expect(errors.first.message, contains('linux'));
+        expect(closeCount, 1);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
     });
 
     testWidgets('unsupported platform shows fallback text and calls onClose',
         (tester) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+      try {
+        int closeCount = 0;
 
-      int closeCount = 0;
+        await tester.pumpWidget(MaterialApp(
+          home: AxeptioConsentView(
+            consentUrl: testUri,
+            onJsEvent: (_, __) {},
+            onClose: () => closeCount++,
+            onError: (_) {},
+          ),
+        ));
+        await tester.pump();
 
-      await tester.pumpWidget(MaterialApp(
-        home: AxeptioConsentView(
-          consentUrl: testUri,
-          onJsEvent: (_, __) {},
-          onClose: () => closeCount++,
-          onError: (_) {},
-        ),
-      ));
-      await tester.pump();
-
-      debugDefaultTargetPlatformOverride = null;
-
-      expect(closeCount, 1);
-      expect(find.text('Consent webview not available'), findsOneWidget);
+        expect(closeCount, 1);
+        expect(find.text('Consent webview not available'), findsOneWidget);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
     });
   });
 
@@ -696,25 +705,26 @@ void main() {
 
     testWidgets('macOS calls onError and onClose', (tester) async {
       debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+      try {
+        final errors = <AxeptioException>[];
+        int closeCount = 0;
 
-      final errors = <AxeptioException>[];
-      int closeCount = 0;
+        await tester.pumpWidget(MaterialApp(
+          home: AxeptioConsentView(
+            consentUrl: testUri,
+            onJsEvent: (_, __) {},
+            onClose: () => closeCount++,
+            onError: (e) => errors.add(e),
+          ),
+        ));
+        await tester.pump();
 
-      await tester.pumpWidget(MaterialApp(
-        home: AxeptioConsentView(
-          consentUrl: testUri,
-          onJsEvent: (_, __) {},
-          onClose: () => closeCount++,
-          onError: (e) => errors.add(e),
-        ),
-      ));
-      await tester.pump();
-
-      debugDefaultTargetPlatformOverride = null;
-
-      expect(errors, hasLength(1));
-      expect(errors.first.message, contains('macOS'));
-      expect(closeCount, 1);
+        expect(errors, hasLength(1));
+        expect(errors.first.message, contains('macOS'));
+        expect(closeCount, 1);
+      } finally {
+        debugDefaultTargetPlatformOverride = null;
+      }
     });
   });
 }

--- a/test/webview/axeptio_consent_view_test.dart
+++ b/test/webview/axeptio_consent_view_test.dart
@@ -5,11 +5,17 @@ import 'package:axeptio_sdk/src/webview/axeptio_consent_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:webview_flutter_platform_interface/webview_flutter_platform_interface.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   final testUri = Uri.parse('https://static.axept.io/test.html');
+
+  setUpAll(() {
+    // Provide a minimal WebView mock so Android code path doesn't crash
+    WebViewPlatform.instance = _MockWebViewPlatform();
+  });
 
   group('AxeptioConsentView widget', () {
     testWidgets('renders Scaffold', (tester) async {
@@ -305,4 +311,86 @@ void main() {
       expect(closeCount, 1);
     });
   });
+}
+
+// Minimal mock WebView platform for Android code path in tests
+class _MockWebViewPlatform extends WebViewPlatform {
+  @override
+  PlatformWebViewController createPlatformWebViewController(
+      PlatformWebViewControllerCreationParams params) {
+    return _MockWebViewController(params);
+  }
+
+  @override
+  PlatformWebViewWidget createPlatformWebViewWidget(
+      PlatformWebViewWidgetCreationParams params) {
+    return _MockWebViewWidget(params);
+  }
+
+  @override
+  PlatformWebViewCookieManager createPlatformCookieManager(
+      PlatformWebViewCookieManagerCreationParams params) {
+    return _MockCookieManager(params);
+  }
+
+  @override
+  PlatformNavigationDelegate createPlatformNavigationDelegate(
+      PlatformNavigationDelegateCreationParams params) {
+    return _MockNavigationDelegate(params);
+  }
+}
+
+class _MockWebViewController extends PlatformWebViewController {
+  _MockWebViewController(super.params) : super.implementation();
+  @override
+  Future<void> setJavaScriptMode(JavaScriptMode javaScriptMode) async {}
+  @override
+  Future<void> setBackgroundColor(Color color) async {}
+  @override
+  Future<void> setPlatformNavigationDelegate(
+      PlatformNavigationDelegate handler) async {}
+  @override
+  Future<void> addJavaScriptChannel(
+      JavaScriptChannelParams javaScriptChannelParams) async {}
+  @override
+  Future<void> removeJavaScriptChannel(String javaScriptChannelName) async {}
+  @override
+  Future<void> loadRequest(LoadRequestParams params) async {}
+  @override
+  Future<void> runJavaScript(String javaScript) async {}
+  @override
+  Future<Object> runJavaScriptReturningResult(String javaScript) async => '';
+}
+
+class _MockWebViewWidget extends PlatformWebViewWidget {
+  _MockWebViewWidget(super.params) : super.implementation();
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+class _MockCookieManager extends PlatformWebViewCookieManager {
+  _MockCookieManager(super.params) : super.implementation();
+}
+
+class _MockNavigationDelegate extends PlatformNavigationDelegate {
+  _MockNavigationDelegate(super.params) : super.implementation();
+  @override
+  Future<void> setOnNavigationRequest(
+      NavigationRequestCallback onNavigationRequest) async {}
+  @override
+  Future<void> setOnPageStarted(PageEventCallback onPageStarted) async {}
+  @override
+  Future<void> setOnPageFinished(PageEventCallback onPageFinished) async {}
+  @override
+  Future<void> setOnProgress(ProgressCallback onProgress) async {}
+  @override
+  Future<void> setOnWebResourceError(
+      WebResourceErrorCallback onWebResourceError) async {}
+  @override
+  Future<void> setOnUrlChange(UrlChangeCallback onUrlChange) async {}
+  @override
+  Future<void> setOnHttpAuthRequest(
+      HttpAuthRequestCallback onHttpAuthRequest) async {}
+  @override
+  Future<void> setOnHttpError(HttpResponseErrorCallback onHttpError) async {}
 }

--- a/test/webview/axeptio_consent_view_test.dart
+++ b/test/webview/axeptio_consent_view_test.dart
@@ -14,7 +14,9 @@ void main() {
   final testUri = Uri.parse('https://static.axept.io/test.html');
 
   setUpAll(() {
-    // Provide a minimal WebView mock so Android code path doesn't crash
+    // Provide a minimal WebView mock so Android code path doesn't crash.
+    // WebViewPlatform.instance is initially null in tests and the setter
+    // rejects null values, so we only set it once and don't restore.
     WebViewPlatform.instance = _CapturingWebViewPlatform();
   });
 
@@ -93,12 +95,12 @@ void main() {
       ));
       await tester.pump(); // process post-frame callback
 
+      debugDefaultTargetPlatformOverride = null;
+
       expect(errors, hasLength(1));
       expect(errors.first, isA<AxeptioWebViewException>());
       expect(errors.first.message, contains('linux'));
       expect(closeCount, 1);
-
-      debugDefaultTargetPlatformOverride = null;
     });
 
     testWidgets('unsupported platform shows fallback text and calls onClose',
@@ -117,10 +119,10 @@ void main() {
       ));
       await tester.pump();
 
+      debugDefaultTargetPlatformOverride = null;
+
       expect(closeCount, 1);
       expect(find.text('Consent webview not available'), findsOneWidget);
-
-      debugDefaultTargetPlatformOverride = null;
     });
   });
 
@@ -458,18 +460,22 @@ void main() {
           greaterThan(callsAfterFirst));
     });
 
-    testWidgets('onNavigationRequest allows https and about schemes',
+    testWidgets('onNavigationRequest allows consent host and about scheme',
         (tester) async {
       await buildAndroidWidget(tester);
       final onNavRequest = capturedDelegate.capturedOnNavigationRequest!;
 
-      final httpsResult = await onNavRequest(const NavigationRequest(
-          url: 'https://example.com', isMainFrame: true));
-      expect(httpsResult, NavigationDecision.navigate);
+      final consentHostResult = await onNavRequest(const NavigationRequest(
+          url: 'https://static.axept.io/some-page', isMainFrame: true));
+      expect(consentHostResult, NavigationDecision.navigate);
 
       final aboutResult = await onNavRequest(
           const NavigationRequest(url: 'about:blank', isMainFrame: true));
       expect(aboutResult, NavigationDecision.navigate);
+
+      final otherHostResult = await onNavRequest(const NavigationRequest(
+          url: 'https://example.com', isMainFrame: true));
+      expect(otherHostResult, NavigationDecision.prevent);
     });
 
     testWidgets('onNavigationRequest blocks non-https/about schemes',
@@ -704,11 +710,11 @@ void main() {
       ));
       await tester.pump();
 
+      debugDefaultTargetPlatformOverride = null;
+
       expect(errors, hasLength(1));
       expect(errors.first.message, contains('macOS'));
       expect(closeCount, 1);
-
-      debugDefaultTargetPlatformOverride = null;
     });
   });
 }

--- a/test/webview/axeptio_consent_view_test.dart
+++ b/test/webview/axeptio_consent_view_test.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:axeptio_sdk/src/exceptions/axeptio_exceptions.dart';
 import 'package:axeptio_sdk/src/webview/axeptio_consent_view.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,7 +15,7 @@ void main() {
 
   setUpAll(() {
     // Provide a minimal WebView mock so Android code path doesn't crash
-    WebViewPlatform.instance = _MockWebViewPlatform();
+    WebViewPlatform.instance = _CapturingWebViewPlatform();
   });
 
   group('AxeptioConsentView widget', () {
@@ -73,6 +74,53 @@ void main() {
       ));
 
       expect(find.byType(Scaffold), findsOneWidget);
+    });
+
+    testWidgets('unsupported platform calls onError and onClose',
+        (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.linux;
+
+      final errors = <AxeptioException>[];
+      int closeCount = 0;
+
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          consentUrl: testUri,
+          onJsEvent: (_, __) {},
+          onClose: () => closeCount++,
+          onError: (e) => errors.add(e),
+        ),
+      ));
+      await tester.pump(); // process post-frame callback
+
+      expect(errors, hasLength(1));
+      expect(errors.first, isA<AxeptioWebViewException>());
+      expect(errors.first.message, contains('linux'));
+      expect(closeCount, 1);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
+
+    testWidgets('unsupported platform shows fallback text and calls onClose',
+        (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.windows;
+
+      int closeCount = 0;
+
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          consentUrl: testUri,
+          onJsEvent: (_, __) {},
+          onClose: () => closeCount++,
+          onError: (_) {},
+        ),
+      ));
+      await tester.pump();
+
+      expect(closeCount, 1);
+      expect(find.text('Consent webview not available'), findsOneWidget);
+
+      debugDefaultTargetPlatformOverride = null;
     });
   });
 
@@ -146,13 +194,9 @@ void main() {
         'app:cookies:ready with showConsentManager==true bypasses showCmp check',
         (tester) async {
       await buildWidget(tester, showConsentManager: true);
-      // With showConsentManager, it tries to call runJavaScript via the channel.
-      // Since there's no native view in tests, the channel won't exist,
-      // but it shouldn't crash.
       stateKey.currentState!.simulateJsEvent('app:cookies:ready',
           jsonEncode({'subscription': true, 'showCmp': false}));
       await tester.pump();
-      // Should NOT close because showConsentManager takes a different path
       expect(closeCount, 0);
     });
 
@@ -310,15 +354,378 @@ void main() {
       await tester.pump();
       expect(closeCount, 1);
     });
+
+    testWidgets('onJsEvent with non-Map arguments is ignored', (tester) async {
+      await buildWidget(tester);
+      await stateKey.currentState!.handleNativeCall(
+        const MethodCall('onJsEvent', 'not a map'),
+      );
+      expect(jsEvents, isEmpty);
+    });
+
+    testWidgets('onError with non-Map arguments is ignored', (tester) async {
+      await buildWidget(tester);
+      await stateKey.currentState!.handleNativeCall(
+        const MethodCall('onError', 'not a map'),
+      );
+      expect(errors, isEmpty);
+    });
+
+    testWidgets('onError without type omits type suffix', (tester) async {
+      await buildWidget(tester);
+      await stateKey.currentState!.handleNativeCall(
+        const MethodCall('onError', {'message': 'plain error'}),
+      );
+      expect(errors, hasLength(1));
+      expect(errors.first.message, contains('plain error'));
+      expect(errors.first.message, isNot(contains('type=')));
+    });
+  });
+
+  group('Android WebView navigation delegate callbacks', () {
+    late _CapturingNavigationDelegate capturedDelegate;
+    late _CapturingWebViewController capturedController;
+    late List<AxeptioException> errors;
+    late int closeCount;
+
+    Future<void> buildAndroidWidget(
+      WidgetTester tester, {
+      bool attDenied = false,
+      String? storedTcString,
+    }) async {
+      errors = [];
+      closeCount = 0;
+
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          consentUrl: testUri,
+          onJsEvent: (_, __) {},
+          onClose: () => closeCount++,
+          onError: (e) => errors.add(e),
+          attDenied: attDenied,
+          storedTcString: storedTcString,
+        ),
+      ));
+
+      // Retrieve captured mocks from the platform
+      final platform = WebViewPlatform.instance! as _CapturingWebViewPlatform;
+      capturedDelegate = platform.lastDelegate!;
+      capturedController = platform.lastController!;
+    }
+
+    testWidgets('onPageStarted resets injection and injects scripts',
+        (tester) async {
+      await buildAndroidWidget(tester);
+      final onPageStarted = capturedDelegate.capturedOnPageStarted!;
+
+      // First call: scripts injected
+      capturedController.runJavaScriptCalls.clear();
+      onPageStarted('https://example.com');
+      await tester.pump();
+      // Should have called runJavaScript for localStorage + polyfill
+      expect(capturedController.runJavaScriptCalls.length,
+          greaterThanOrEqualTo(1));
+    });
+
+    testWidgets('onPageFinished injects scripts', (tester) async {
+      await buildAndroidWidget(tester);
+      final onPageFinished = capturedDelegate.capturedOnPageFinished!;
+
+      capturedController.runJavaScriptCalls.clear();
+      onPageFinished('https://example.com');
+      await tester.pump();
+      expect(capturedController.runJavaScriptCalls.length,
+          greaterThanOrEqualTo(1));
+    });
+
+    testWidgets('onPageStarted resets _androidInjected for re-navigation',
+        (tester) async {
+      await buildAndroidWidget(tester);
+      final onPageStarted = capturedDelegate.capturedOnPageStarted!;
+      final onPageFinished = capturedDelegate.capturedOnPageFinished!;
+
+      // First: complete a full navigation
+      onPageStarted('https://example.com');
+      await tester.pump();
+      onPageFinished('https://example.com');
+      await tester.pump();
+      final callsAfterFirst = capturedController.runJavaScriptCalls.length;
+
+      // Second navigation: onPageStarted should reset and re-inject
+      onPageStarted('https://example.com/page2');
+      await tester.pump();
+      expect(capturedController.runJavaScriptCalls.length,
+          greaterThan(callsAfterFirst));
+    });
+
+    testWidgets('onNavigationRequest allows https and about schemes',
+        (tester) async {
+      await buildAndroidWidget(tester);
+      final onNavRequest = capturedDelegate.capturedOnNavigationRequest!;
+
+      final httpsResult = await onNavRequest(const NavigationRequest(
+          url: 'https://example.com', isMainFrame: true));
+      expect(httpsResult, NavigationDecision.navigate);
+
+      final aboutResult = await onNavRequest(
+          const NavigationRequest(url: 'about:blank', isMainFrame: true));
+      expect(aboutResult, NavigationDecision.navigate);
+    });
+
+    testWidgets('onNavigationRequest blocks non-https/about schemes',
+        (tester) async {
+      await buildAndroidWidget(tester);
+      final onNavRequest = capturedDelegate.capturedOnNavigationRequest!;
+
+      final httpResult = await onNavRequest(const NavigationRequest(
+          url: 'http://example.com', isMainFrame: true));
+      expect(httpResult, NavigationDecision.prevent);
+
+      final jsResult = await onNavRequest(const NavigationRequest(
+          url: 'javascript:void(0)', isMainFrame: true));
+      expect(jsResult, NavigationDecision.prevent);
+    });
+
+    testWidgets('onWebResourceError for main frame reports error',
+        (tester) async {
+      await buildAndroidWidget(tester);
+      final onWebResourceError = capturedDelegate.capturedOnWebResourceError!;
+
+      onWebResourceError(const WebResourceError(
+        errorCode: -2,
+        description: 'net::ERR_FAILED',
+        isForMainFrame: true,
+        errorType: WebResourceErrorType.connect,
+      ));
+      expect(errors, hasLength(1));
+      expect(errors.first, isA<AxeptioNetworkException>());
+      expect(errors.first.message, contains('net::ERR_FAILED'));
+    });
+
+    testWidgets('onWebResourceError for sub-frame is ignored', (tester) async {
+      await buildAndroidWidget(tester);
+      final onWebResourceError = capturedDelegate.capturedOnWebResourceError!;
+
+      onWebResourceError(const WebResourceError(
+        errorCode: -2,
+        description: 'sub-frame error',
+        isForMainFrame: false,
+        errorType: WebResourceErrorType.connect,
+      ));
+      expect(errors, isEmpty);
+    });
+
+    testWidgets('onHttpError with status >= 400 reports error', (tester) async {
+      await buildAndroidWidget(tester);
+      final onHttpError = capturedDelegate.capturedOnHttpError!;
+
+      onHttpError(HttpResponseError(
+        response: WebResourceResponse(
+            uri: Uri.parse('https://example.com'), statusCode: 500),
+      ));
+      expect(errors, hasLength(1));
+      expect(errors.first, isA<AxeptioNetworkException>());
+      expect(errors.first.message, contains('500'));
+    });
+
+    testWidgets('onHttpError with status < 400 is ignored', (tester) async {
+      await buildAndroidWidget(tester);
+      final onHttpError = capturedDelegate.capturedOnHttpError!;
+
+      onHttpError(HttpResponseError(
+        response: WebResourceResponse(
+            uri: Uri.parse('https://example.com'), statusCode: 200),
+      ));
+      expect(errors, isEmpty);
+    });
+
+    testWidgets('localStorage injection includes attDenied and tcString',
+        (tester) async {
+      await buildAndroidWidget(tester,
+          attDenied: true, storedTcString: 'TC123');
+
+      // Trigger page finished to inject scripts
+      capturedController.runJavaScriptCalls.clear();
+      capturedDelegate.capturedOnPageFinished!('https://example.com');
+      await tester.pump();
+
+      // Check that localStorage calls include attDenied and tcString
+      final lsCalls = capturedController.runJavaScriptCalls
+          .where((s) => s.contains('localStorage'))
+          .toList();
+      expect(lsCalls, isNotEmpty);
+      final lsScript = lsCalls.first;
+      expect(lsScript, contains('_ax_app_att_denied'));
+      expect(lsScript, contains('_ax_tcstring'));
+      expect(lsScript, contains('TC123'));
+    });
+
+    testWidgets('polyfill injection failure does not set _androidInjected',
+        (tester) async {
+      await buildAndroidWidget(tester);
+
+      // Make polyfill injection fail
+      capturedController.shouldFailRunJavaScript = true;
+
+      capturedDelegate.capturedOnPageFinished!('https://example.com');
+      await tester.pump();
+      expect(errors, hasLength(1));
+      expect(errors.first.message, contains('Failed to inject polyfill'));
+
+      // Reset failure and try again - should retry since not marked injected
+      capturedController.shouldFailRunJavaScript = false;
+      errors.clear();
+      capturedController.runJavaScriptCalls.clear();
+      capturedDelegate.capturedOnPageFinished!('https://example.com');
+      await tester.pump();
+      expect(capturedController.runJavaScriptCalls, isNotEmpty);
+      expect(errors, isEmpty);
+    });
+
+    testWidgets(
+        'localStorage failure prevents _androidInjected even if polyfill succeeds',
+        (tester) async {
+      await buildAndroidWidget(tester);
+
+      // Make localStorage injection fail (first runJavaScript call)
+      capturedController.failOnLocalStorage = true;
+
+      capturedDelegate.capturedOnPageFinished!('https://example.com');
+      await tester.pump();
+      // Polyfill should still have been injected
+      final polyfillCalls = capturedController.runJavaScriptCalls
+          .where((s) => s.contains('axeptioAppSdk'))
+          .toList();
+      expect(polyfillCalls, isNotEmpty);
+
+      // But _androidInjected should NOT be true, so retry works
+      capturedController.failOnLocalStorage = false;
+      capturedController.runJavaScriptCalls.clear();
+      capturedDelegate.capturedOnPageFinished!('https://example.com');
+      await tester.pump();
+      // Should have injected again since localStorageOk was false last time
+      expect(capturedController.runJavaScriptCalls, isNotEmpty);
+    });
+
+    testWidgets('JS message with valid JSON dispatches event', (tester) async {
+      final jsEvents = <String>[];
+      int evCloseCount = 0;
+
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          consentUrl: testUri,
+          onJsEvent: (name, _) => jsEvents.add(name),
+          onClose: () => evCloseCount++,
+          onError: (e) => errors.add(e),
+        ),
+      ));
+
+      final platform = WebViewPlatform.instance! as _CapturingWebViewPlatform;
+      final controller = platform.lastController!;
+      final jsChannel = controller.capturedJsChannel!;
+
+      jsChannel.onMessageReceived(JavaScriptMessage(
+          message: jsonEncode({'name': 'cookies:close', 'payload': null})));
+      expect(jsEvents, contains('cookies:close'));
+      expect(evCloseCount, 1);
+    });
+
+    testWidgets('JS message with invalid JSON is ignored', (tester) async {
+      final jsEvents = <String>[];
+
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          consentUrl: testUri,
+          onJsEvent: (name, _) => jsEvents.add(name),
+          onClose: () {},
+        ),
+      ));
+
+      final platform = WebViewPlatform.instance! as _CapturingWebViewPlatform;
+      final jsChannel = platform.lastController!.capturedJsChannel!;
+
+      jsChannel.onMessageReceived(const JavaScriptMessage(message: 'not json'));
+      expect(jsEvents, isEmpty);
+    });
+
+    testWidgets('JS message with null name is ignored', (tester) async {
+      final jsEvents = <String>[];
+
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          consentUrl: testUri,
+          onJsEvent: (name, _) => jsEvents.add(name),
+          onClose: () {},
+        ),
+      ));
+
+      final platform = WebViewPlatform.instance! as _CapturingWebViewPlatform;
+      final jsChannel = platform.lastController!.capturedJsChannel!;
+
+      jsChannel.onMessageReceived(JavaScriptMessage(
+          message: jsonEncode({'name': null, 'payload': null})));
+      expect(jsEvents, isEmpty);
+    });
+
+    testWidgets('loadRequest is called with consent URL', (tester) async {
+      await buildAndroidWidget(tester);
+      expect(capturedController.loadedUrl, testUri.toString());
+    });
+  });
+
+  group('AxeptioConsentView build for different platforms', () {
+    testWidgets('Android renders WebViewWidget', (tester) async {
+      // default test platform is android
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          consentUrl: testUri,
+          onJsEvent: (_, __) {},
+          onClose: () {},
+        ),
+      ));
+
+      // The mock WebViewWidget renders SizedBox.shrink
+      expect(find.byType(SizedBox), findsOneWidget);
+    });
+
+    testWidgets('macOS calls onError and onClose', (tester) async {
+      debugDefaultTargetPlatformOverride = TargetPlatform.macOS;
+
+      final errors = <AxeptioException>[];
+      int closeCount = 0;
+
+      await tester.pumpWidget(MaterialApp(
+        home: AxeptioConsentView(
+          consentUrl: testUri,
+          onJsEvent: (_, __) {},
+          onClose: () => closeCount++,
+          onError: (e) => errors.add(e),
+        ),
+      ));
+      await tester.pump();
+
+      expect(errors, hasLength(1));
+      expect(errors.first.message, contains('macOS'));
+      expect(closeCount, 1);
+
+      debugDefaultTargetPlatformOverride = null;
+    });
   });
 }
 
-// Minimal mock WebView platform for Android code path in tests
-class _MockWebViewPlatform extends WebViewPlatform {
+// ============================================================================
+// Capturing mock infrastructure
+// ============================================================================
+
+class _CapturingWebViewPlatform extends WebViewPlatform {
+  _CapturingNavigationDelegate? lastDelegate;
+  _CapturingWebViewController? lastController;
+
   @override
   PlatformWebViewController createPlatformWebViewController(
       PlatformWebViewControllerCreationParams params) {
-    return _MockWebViewController(params);
+    lastController = _CapturingWebViewController(params);
+    return lastController!;
   }
 
   @override
@@ -336,12 +743,20 @@ class _MockWebViewPlatform extends WebViewPlatform {
   @override
   PlatformNavigationDelegate createPlatformNavigationDelegate(
       PlatformNavigationDelegateCreationParams params) {
-    return _MockNavigationDelegate(params);
+    lastDelegate = _CapturingNavigationDelegate(params);
+    return lastDelegate!;
   }
 }
 
-class _MockWebViewController extends PlatformWebViewController {
-  _MockWebViewController(super.params) : super.implementation();
+class _CapturingWebViewController extends PlatformWebViewController {
+  _CapturingWebViewController(super.params) : super.implementation();
+
+  final List<String> runJavaScriptCalls = [];
+  bool shouldFailRunJavaScript = false;
+  bool failOnLocalStorage = false;
+  String? loadedUrl;
+  JavaScriptChannelParams? capturedJsChannel;
+
   @override
   Future<void> setJavaScriptMode(JavaScriptMode javaScriptMode) async {}
   @override
@@ -351,13 +766,28 @@ class _MockWebViewController extends PlatformWebViewController {
       PlatformNavigationDelegate handler) async {}
   @override
   Future<void> addJavaScriptChannel(
-      JavaScriptChannelParams javaScriptChannelParams) async {}
+      JavaScriptChannelParams javaScriptChannelParams) async {
+    capturedJsChannel = javaScriptChannelParams;
+  }
+
   @override
   Future<void> removeJavaScriptChannel(String javaScriptChannelName) async {}
   @override
-  Future<void> loadRequest(LoadRequestParams params) async {}
+  Future<void> loadRequest(LoadRequestParams params) async {
+    loadedUrl = params.uri.toString();
+  }
+
   @override
-  Future<void> runJavaScript(String javaScript) async {}
+  Future<void> runJavaScript(String javaScript) async {
+    if (failOnLocalStorage && javaScript.contains('localStorage')) {
+      throw Exception('localStorage not available');
+    }
+    if (shouldFailRunJavaScript && javaScript.contains('axeptioAppSdk')) {
+      throw Exception('JS injection failed');
+    }
+    runJavaScriptCalls.add(javaScript);
+  }
+
   @override
   Future<Object> runJavaScriptReturningResult(String javaScript) async => '';
 }
@@ -372,25 +802,46 @@ class _MockCookieManager extends PlatformWebViewCookieManager {
   _MockCookieManager(super.params) : super.implementation();
 }
 
-class _MockNavigationDelegate extends PlatformNavigationDelegate {
-  _MockNavigationDelegate(super.params) : super.implementation();
+class _CapturingNavigationDelegate extends PlatformNavigationDelegate {
+  _CapturingNavigationDelegate(super.params) : super.implementation();
+
+  PageEventCallback? capturedOnPageStarted;
+  PageEventCallback? capturedOnPageFinished;
+  NavigationRequestCallback? capturedOnNavigationRequest;
+  WebResourceErrorCallback? capturedOnWebResourceError;
+  HttpResponseErrorCallback? capturedOnHttpError;
+
   @override
   Future<void> setOnNavigationRequest(
-      NavigationRequestCallback onNavigationRequest) async {}
+      NavigationRequestCallback onNavigationRequest) async {
+    capturedOnNavigationRequest = onNavigationRequest;
+  }
+
   @override
-  Future<void> setOnPageStarted(PageEventCallback onPageStarted) async {}
+  Future<void> setOnPageStarted(PageEventCallback onPageStarted) async {
+    capturedOnPageStarted = onPageStarted;
+  }
+
   @override
-  Future<void> setOnPageFinished(PageEventCallback onPageFinished) async {}
+  Future<void> setOnPageFinished(PageEventCallback onPageFinished) async {
+    capturedOnPageFinished = onPageFinished;
+  }
+
   @override
   Future<void> setOnProgress(ProgressCallback onProgress) async {}
   @override
   Future<void> setOnWebResourceError(
-      WebResourceErrorCallback onWebResourceError) async {}
+      WebResourceErrorCallback onWebResourceError) async {
+    capturedOnWebResourceError = onWebResourceError;
+  }
+
   @override
   Future<void> setOnUrlChange(UrlChangeCallback onUrlChange) async {}
   @override
   Future<void> setOnHttpAuthRequest(
       HttpAuthRequestCallback onHttpAuthRequest) async {}
   @override
-  Future<void> setOnHttpError(HttpResponseErrorCallback onHttpError) async {}
+  Future<void> setOnHttpError(HttpResponseErrorCallback onHttpError) async {
+    capturedOnHttpError = onHttpError;
+  }
 }


### PR DESCRIPTION
## Summary
- Add Android consent webview using `webview_flutter` with JS channel bridge for event communication
- Implement polyfill that bridges `window.axeptioAppSdk.onEvent()` to Flutter's JS channel (`window.axeptioSdk.postMessage`)
- Fix example app: defer `MobileAds.instance.initialize()` to after consent flow (was freezing Dart event loop)
- Restrict Android navigation to consent host only (matching iOS behavior)
- Set transparent WebView background for overlay appearance
- Bump example `compileSdk` to 36 for plugin compatibility
- Handle unsupported platforms (web, macOS, Linux, Windows) with error + close
- Reset injection flag on each navigation for proper re-injection
- Gate `loadAd()` behind ads initialization flag

## Test plan
- [x] All 378 tests pass (`flutter test`)
- [x] Coverage at 95.1% (`flutter test --coverage`)
- [x] `flutter analyze` clean
- [ ] Manual test on Android emulator: consent popup appears with transparent overlay
- [ ] Manual test: accept consent → popup closes, events flow correctly
- [ ] Manual test: re-open consent via button → works
- [ ] Regression test on iOS simulator: consent flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)